### PR TITLE
Initial changes for the handoff from Embark to the community.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Ensure compatibility with rust-gpu nightly rust version
         run: |
-          curl -sSL https://github.com/EmbarkStudios/rust-gpu/raw/main/rust-toolchain.toml | grep -v '^components = ' > rust-toolchain.toml
+          curl -sSL https://github.com/rust-gpu/rust-gpu/raw/main/rust-toolchain.toml | grep -v '^components = ' > rust-toolchain.toml
           cargo check --workspace --all-targets
           rm rust-toolchain.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,9 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pretty-printer with (styled and hyperlinked) HTML output.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/EmbarkStudios/spirt/compare/0.3.0...HEAD
-[0.3.0]: https://github.com/EmbarkStudios/spirt/compare/0.2.0...0.3.0
-[0.2.0]: https://github.com/EmbarkStudios/spirt/compare/0.1.0...0.2.0
+[Unreleased]: https://github.com/rust-gpu/spirt/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/rust-gpu/spirt/compare/0.2.0...0.3.0
+[0.2.0]: https://github.com/rust-gpu/spirt/compare/0.1.0...0.2.0
 <!-- HACK(eddyb) `0.0.0` doesn't exist as a "tag before the initial commit", but
      the commit hash referenced here is the newest from `opensource-template`,
      that predates `0.1.0`, i.e. the `opensource-template` parent of the merge
@@ -126,4 +126,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      suitable for a comparison point, as GitHub will dutifully list all commits
      that don't come from `opensource-template`, even the initial commit itself!
 -->
-[0.1.0]: https://github.com/EmbarkStudios/spirt/compare/c5d63c6974d03e1495eba2c72ff403a246586a40...0.1.0
+[0.1.0]: https://github.com/rust-gpu/spirt/compare/c5d63c6974d03e1495eba2c72ff403a246586a40...0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,8 +55,8 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at opensource@embark-studios.com. All
-complaints will be reviewed and investigated and will result in a response that
+reported by contacting the project team.
+All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,6 @@
-# Embark Contributor Guidelines
+# Contributor Guidelines
 
-Welcome! This project is created by the team at [Embark Studios](https://embark.games). We're glad you're interested in contributing! We welcome contributions from people of all backgrounds who are interested in making great software with us.
-
-At Embark, we aspire to empower everyone to create interactive experiences. To do this, we're exploring and pushing the boundaries of new technologies, and sharing our learnings with the open source community.
-
-If you have ideas for collaboration, email us at opensource@embark-studios.com.
-
-We're also hiring full-time engineers to work with us in Stockholm! Check out our current job postings [here](https://www.embark-studios.com/jobs).
+Welcome! We're glad you're interested in contributing! We welcome contributions from people of all backgrounds who are interested in making great software with us.
 
 ## Issues
 
@@ -46,30 +40,14 @@ You can comment on the issue to let others know you're interested in working on 
 
 5. A maintainer will review your pull request and may ask you to make changes.
 
-## Code Guidelines
-
-### Rust
-
-You can read about our standards and recommendations for working with Rust [here](https://github.com/EmbarkStudios/rust-ecosystem/blob/main/guidelines.md).
-
-### Python
-
-We recommend following [PEP8 conventions](https://www.python.org/dev/peps/pep-0008/) when working with Python modules.
-
-### JavaScript & TypeScript
-
-We use [Prettier](https://prettier.io/) with the default settings to auto-format our JavaScript and TypeScript code.
-
 ## Licensing
 
-Unless otherwise specified, all Embark open source projects shall comply with the Rust standard licensing model (MIT + Apache 2.0) and are thereby licensed under a dual license, allowing licensees to choose either MIT OR Apache-2.0 at their option.
+Unless otherwise specified, this project shall comply with the Rust standard licensing model (MIT + Apache 2.0) and are thereby licensed under a dual license, allowing licensees to choose either MIT OR Apache-2.0 at their option.
 
 ## Contributor Terms
 
-Thank you for your interest in Embark Studios’ open source project. By providing a contribution (new or modified code, other input, feedback or suggestions etc.) you agree to these Contributor Terms.
+By providing a contribution (new or modified code, other input, feedback or suggestions etc.) you agree to these Contributor Terms.
 
 You confirm that each of your contributions has been created by you and that you are the copyright owner. You also confirm that you have the right to provide the contribution to us and that you do it under the Rust dual licence model (MIT + Apache 2.0).
 
-If you want to contribute something that is not your original creation, you may submit it to Embark Studios separately from any contribution, including details of its source and of any license or other restriction (such as related patents, trademarks,  agreements etc.)
-
-Please also note that our projects are released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md) to ensure that they are welcoming places for everyone to contribute. By participating in any Embark Studios open source project, you agree to keep to the Contributor Code of Conduct.
+Please also note that our projects are released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md) to ensure that they are welcoming places for everyone to contribute. By participating in our open source project, you agree to keep to the Contributor Code of Conduct.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "spirt"
 description = "Shader-focused IR to target, transform and translate from."
-repository = "https://github.com/EmbarkStudios/spirt"
-homepage = "https://github.com/EmbarkStudios/spirt"
+repository = "https://github.com/rust-gpu/spirt"
+homepage = "https://github.com/rust-gpu/spirt"
 version = "0.3.0"
-authors = ["Embark <opensource@embark-studios.com>"]
+authors = ["spirt contributors", "Embark <opensource@embark-studios.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,5 @@
-Copyright (c) 2019 Embark Studios
+Copyright (c) 2019-2024 Embark Studios
+Copyright (c) 2024 spirt contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@
 
 **⋯🢒 🇹arget 🠆 🇹ransform 🠆 🇹ranslate ⋯🢒**
 
-[![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://embark.dev)
 [![Crates.io](https://img.shields.io/crates/v/spirt.svg)](https://crates.io/crates/spirt)
 [![Docs](https://docs.rs/spirt/badge.svg)](https://docs.rs/spirt)
-[![Git Docs](https://img.shields.io/badge/git%20main%20docs-published-blue)](https://embarkstudios.github.io/spirt/spirt/index.html)
-[![dependency status](https://deps.rs/repo/github/EmbarkStudios/spirt/status.svg)](https://deps.rs/repo/github/EmbarkStudios/spirt)
-[![Build status](https://github.com/EmbarkStudios/spirt/workflows/CI/badge.svg)](https://github.com/EmbarkStudios/spirt/actions)
+[![Git Docs](https://img.shields.io/badge/git%20main%20docs-published-blue)](https://rust-gpu.github.io/spirt/spirt/index.html)
+[![Build status](https://github.com/rust-gpu/spirt/workflows/CI/badge.svg)](https://github.com/rust-gpu/spirt/actions)
 </div>
 
 **SPIR-🇹** is a research project aimed at exploring shader-oriented IR designs derived from SPIR-V, and producing a framework around such an IR to facilitate advanced compilation pipelines, beyond what existing SPIR-V tooling allows for.
@@ -40,7 +38,7 @@ The names SPIR, SPIR-V, as well as related names, marks, emblems and images are 
 
 🚧 *This project is in active design and development, many details can and will change* 🚧
 
-If you're interested in using **SPIR-🇹** yourself, you may want to first take a look at [the issue tracker](https://github.com/EmbarkStudios/spirt/issues) for relevant issues, and even open new ones describing your usecase.  
+If you're interested in using **SPIR-🇹** yourself, you may want to first take a look at [the issue tracker](https://github.com/rust-gpu/spirt/issues) for relevant issues, and even open new ones describing your usecase.  
 With the initial focus being on [Rust-GPU]'s usecase, various (otherwise desirable) functionality/APIs/docs may be lacking, or rapidly changing - at the same time, discussions around widening the scope and usability of **SPIR-🇹** _in the long term_ are still welcome.
 
 ### Non-goals (at least in the short term)
@@ -222,7 +220,7 @@ We welcome community contributions to this project.
 Please read our [Contributor Guide](CONTRIBUTING.md) for more information on how to get started.
 Please also read our [Contributor Terms](CONTRIBUTING.md#contributor-terms) before you make any contributions.
 
-Any contribution intentionally submitted for inclusion in an Embark Studios project, shall comply with the Rust standard licensing model (MIT OR Apache 2.0) and therefore be dual licensed as described below, without any additional terms or conditions:
+Any contribution intentionally submitted for inclusion shall comply with the Rust standard licensing model (MIT OR Apache 2.0) and therefore be dual licensed as described below, without any additional terms or conditions:
 
 ### License
 
@@ -233,6 +231,6 @@ This contribution is dual licensed under EITHER OF
 
 at your option.
 
-For clarity, "your" refers to Embark or any other licensee/user of the contribution.
+For clarity, "your" refers to any licensee/user of the contribution.
 
-[Rust-GPU]: https://github.com/EmbarkStudios/rust-gpu
+[Rust-GPU]: https://github.com/rust-gpu/rust-gpu

--- a/release.toml
+++ b/release.toml
@@ -2,10 +2,10 @@ pre-release-commit-message = "Release {{version}}"
 tag-message = "Release {{version}}"
 tag-name = "{{version}}"
 pre-release-replacements = [
-  { file = "Cargo.toml", prerelease = true, search = "repository = \"https://github.com/EmbarkStudios/spirt\"", replace = "repository = \"https://github.com/EmbarkStudios/spirt/tree/{{tag_name}}\"" },
+  { file = "Cargo.toml", prerelease = true, search = "repository = \"https://github.com/rust-gpu/spirt\"", replace = "repository = \"https://github.com/rust-gpu/spirt/tree/{{tag_name}}\"" },
   { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
   { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}" },
   { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
   { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate" },
-  { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/EmbarkStudios/spirt/compare/{{tag_name}}...HEAD" },
+  { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/rust-gpu/spirt/compare/{{tag_name}}...HEAD" },
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
     git_main_docs,
     doc = concat!(
         "[`", env!("CARGO_PKG_NAME"), " @ ", env!("GIT_MAIN_DESCRIBE"), "`'s `README`]",
-        "(https://github.com/EmbarkStudios/spirt/tree/", env!("GIT_MAIN_COMMIT"), "#readme)*  "
+        "(https://github.com/rust-gpu/spirt/tree/", env!("GIT_MAIN_COMMIT"), "#readme)*  "
     )
 )]
 #![cfg_attr(
@@ -42,7 +42,7 @@
     doc = concat!("`", env!("CARGO_PKG_NAME"), "`'s `README`*  ")
 )]
 //!
-//! *Check out also [the `EmbarkStudios/spirt` GitHub repository](https://github.com/EmbarkStudios/spirt),
+//! *Check out also [the `rust-gpu/spirt` GitHub repository](https://github.com/rust-gpu/spirt),
 //! for any additional developments.*
 //!
 //! #### Notable types/modules


### PR DESCRIPTION
This will likely fail CI until the new `rust-gpu` repo is public.