### PR TITLE
Panic structurization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "convert_case"
@@ -22,22 +22,22 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elsa"
@@ -57,15 +57,15 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "indexmap"
-version = "2.2.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -88,15 +88,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "longest-increasing-subsequence"
@@ -105,19 +105,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.78"
+name = "memchr"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -130,61 +136,62 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
 ]
@@ -216,20 +223,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -238,6 +234,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -78,7 +78,7 @@ impl ControlFlowGraph {
     /// reverse post-order (RPO).
     ///
     /// RPO iteration over a CFG provides certain guarantees, most importantly
-    /// that SSA definitions are visited before any of their uses.
+    /// that dominators are visited before the entire subgraph they dominate.
     pub fn rev_post_order(
         &self,
         func_def_body: &FuncDefBody,

--- a/src/cfgssa.rs
+++ b/src/cfgssa.rs
@@ -1,0 +1,723 @@
+//! Tools for working with control-flow graphs that contain SSA dataflow
+//! (often abbreviated to `CFG<SSA>` or similar).
+//!
+//! The defining characteristic of SSA dataflow in a control-flow graph is that
+//! SSA definitions (of values, e.g. the result of an instruction) are "visible"
+//! from all the CFG locations they dominate (i.e. the locations that can only
+//! be reached by passing through the definition first), and can therefore be
+//! directly used arbitrarily far away in the CFG with no annotations required
+//! anywhere in the CFG between the definition and its uses.
+//!
+//! While "def dominates use" is sufficient to ensure the value can traverse
+//! the necessary paths (between def and use) in the CFG, a lot of care must
+//! be taken to preserve the correctness of such implicit dataflow across all
+//! transformations, and it's overall far more fragile than the local dataflow
+//! of e.g. phi nodes (or their alternative "block arguments"), or in SPIR-T's
+//! case, `ControlRegion` inputs and `ControlNode` outputs (inspired by RVSDG,
+//! which has even stricter isolation/locality in its regions).
+
+use crate::{FxIndexMap, FxIndexSet};
+use itertools::Either;
+use rustc_hash::FxHashMap;
+use std::collections::VecDeque;
+use std::hash::Hash;
+
+// HACK(eddyb) to be able to propagate many uses at once while avoiding expensive
+// hierchical indexing (and because the parent block of a def is significant),
+// each block's defs get chunked, with chunks being the size of `FixedBitSet`
+// (i.e. each bit tracks one def in the chunk, and can be propagated together).
+// FIXME(eddyb) in theory, a sparse bitset could expose some of its sparseness
+// to allow chunked addressing/iteration/etc. (but that requires more API design).
+const CHUNK_SIZE: usize = data::FixedBitSet::SIZE;
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Into)]
+struct BlockIdx(usize);
+#[derive(Copy, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Into)]
+struct ChunkIdx(usize);
+#[derive(Copy, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Into)]
+struct DefIdx(usize);
+
+impl DefIdx {
+    fn chunk(self) -> ChunkIdx {
+        ChunkIdx(self.0 / CHUNK_SIZE)
+    }
+}
+
+/// All blocks and ddefinitions they contain, which have to be computed first,
+/// and remain immutable, because where a value is defined (or whether it's at
+/// all part of the function itself) can have non-monotonic effects elsewhere.
+pub struct DefMap<BlockId, DefId, DefType> {
+    blocks_by_id: FxIndexMap<BlockId, BlockDef>,
+    // FIXME(eddyb) should this contain `BlockIdx` instead?
+    chunk_to_block_id: data::KeyedVec<ChunkIdx, BlockId>,
+    chunk_defs: data::KeyedVec<ChunkIdx, [Option<(DefId, DefType)>; CHUNK_SIZE]>,
+    def_id_to_def_idx: FxHashMap<DefId, DefIdx>,
+}
+
+struct BlockDef {
+    last_def_idx: DefIdx,
+}
+
+impl<BlockId: Copy + Eq + Hash, DefId: Copy + Eq + Hash, DefType: Copy> Default
+    for DefMap<BlockId, DefId, DefType>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<BlockId: Copy + Eq + Hash, DefId: Copy + Eq + Hash, DefType: Copy>
+    DefMap<BlockId, DefId, DefType>
+{
+    pub fn new() -> Self {
+        Self {
+            blocks_by_id: Default::default(),
+            chunk_to_block_id: Default::default(),
+            chunk_defs: Default::default(),
+            def_id_to_def_idx: Default::default(),
+        }
+    }
+
+    pub fn add_block(&mut self, block_id: BlockId) {
+        // FIXME(eddyb) disallow accidental re-insertion.
+        self.blocks_by_id.insert(block_id, BlockDef { last_def_idx: DefIdx(!0) });
+    }
+
+    pub fn add_def(&mut self, block_id: BlockId, def_id: DefId, def_type: DefType) {
+        // HACK(eddyb) optimize for repeated definitions in the same block.
+        let block = match self.blocks_by_id.last_mut() {
+            Some((&last_block_id, last_block)) if last_block_id == block_id => last_block,
+            _ => &mut self.blocks_by_id[&block_id],
+        };
+        let def_idx = Some(DefIdx(block.last_def_idx.0.wrapping_add(1)))
+            .filter(|def_idx| def_idx.chunk() == block.last_def_idx.chunk())
+            .unwrap_or_else(|| {
+                let chunk_idx = self.chunk_to_block_id.push(block_id);
+                assert!(chunk_idx == self.chunk_defs.push([None; CHUNK_SIZE]));
+                DefIdx(chunk_idx.0 * CHUNK_SIZE)
+            });
+        block.last_def_idx = def_idx;
+
+        self.chunk_defs[def_idx.chunk()][def_idx.0 % CHUNK_SIZE] = Some((def_id, def_type));
+
+        // FIXME(eddyb) disallow accidental re-insertion.
+        self.def_id_to_def_idx.insert(def_id, def_idx);
+    }
+
+    fn block_id_from_idx(&self, block_idx: BlockIdx) -> BlockId {
+        *self.blocks_by_id.get_index(block_idx.0).unwrap().0
+    }
+}
+
+/// Incremental tracker for definition uses (and CFG edges between blocks),
+/// accumulating the complete set of transitive uses for each block, also known
+/// as the SSA "live set" (corresponding to the starting position of each block).
+pub struct UseAccumulator<'a, BlockId, DefId, DefType> {
+    def_map: &'a DefMap<BlockId, DefId, DefType>,
+
+    blocks: data::KeyedVec<BlockIdx, BlockAcc>,
+
+    // HACK(eddyb) optimize for repeated uses from the same block.
+    most_recent_block_idx: BlockIdx,
+
+    /// Every `block_idx` with non-empty `blocks[block_idx].dirty_chunks`,
+    /// and used for breadth-first propagation through predecessors.
+    //
+    // FIXME(eddyb) some traversal orders might be more effective, but also
+    // the "chunk" granularity might itself be enough to paper over that?
+    propagate_queue: VecDeque<BlockIdx>,
+}
+
+#[derive(Default)]
+struct BlockAcc {
+    // FIXME(eddyb) should this use a bitset? seems likely to be inefficient
+    preds: FxIndexSet<BlockIdx>,
+
+    /// All definitions used in this block (or any other block reachable from it),
+    /// excluding its own definitions, and represented as a sparse bitset.
+    uses: data::SparseMap<ChunkIdx, data::FixedBitSet<usize>>,
+
+    /// All chunks `c` where `uses[c]` has changed since this block has last
+    /// propagated any of its `uses` to its predecessors.
+    dirty_chunks: data::BitSet<ChunkIdx>,
+}
+
+enum AddUsesSource {
+    New(DefIdx),
+    PropagateBackwardsAcrossEdge { target: BlockIdx, only_dirty: bool },
+}
+
+impl<'a, BlockId: Copy + Eq + Hash, DefId: Copy + Eq + Hash, DefType: Copy>
+    UseAccumulator<'a, BlockId, DefId, DefType>
+{
+    pub fn new(def_map: &'a DefMap<BlockId, DefId, DefType>) -> Self {
+        Self {
+            def_map,
+
+            blocks: data::KeyedVec::from_fn(..BlockIdx(def_map.blocks_by_id.len()), |_| {
+                Default::default()
+            }),
+
+            most_recent_block_idx: BlockIdx(0),
+
+            propagate_queue: VecDeque::new(),
+        }
+    }
+
+    // FIXME(eddyb) how inefficient is `FxIndexMap<DefId, DefType>`?
+    // (vs e.g. a bitset combined with not duplicating `DefType`s per-block?)
+    // FIXME(eddyb) naming might not be enough to clarify the semantics,
+    // might be useful to use the liveness (e.g. "live set") jargon?
+    pub fn into_inter_block_uses(
+        mut self,
+    ) -> impl Iterator<Item = (BlockId, FxIndexMap<DefId, DefType>)> + 'a {
+        self.propagate();
+
+        assert!(self.propagate_queue.is_empty());
+
+        self.blocks.into_iter().map(|(block_idx, block_acc)| {
+            assert!(block_acc.dirty_chunks.is_empty());
+
+            (
+                self.def_map.block_id_from_idx(block_idx),
+                block_acc
+                    .uses
+                    .iter()
+                    .flat_map(|(chunk_idx, chunk_uses)| {
+                        let chunk_defs = &self.def_map.chunk_defs[chunk_idx];
+                        chunk_uses.keys().map(move |i| chunk_defs[i].unwrap())
+                    })
+                    .collect(),
+            )
+        })
+    }
+
+    pub fn add_use(&mut self, block_id: BlockId, used_def_id: DefId) {
+        // FIXME(eddyb) use `let ... else`?
+        let &used_def_idx = match self.def_map.def_id_to_def_idx.get(&used_def_id) {
+            // HACK(eddyb) silently ignoring unrecognized defs.
+            None => return,
+            Some(def_idx) => def_idx,
+        };
+
+        // Intra-block uses are not tracked.
+        if self.def_map.chunk_to_block_id[used_def_idx.chunk()] == block_id {
+            return;
+        }
+
+        let block_idx = Some(self.most_recent_block_idx)
+            .filter(|&block_idx| self.def_map.block_id_from_idx(block_idx) == block_id)
+            .unwrap_or_else(|| {
+                BlockIdx(self.def_map.blocks_by_id.get_index_of(&block_id).unwrap())
+            });
+
+        self.add_uses_to(block_idx, AddUsesSource::New(used_def_idx));
+    }
+
+    pub fn add_edge(&mut self, source_block_id: BlockId, target_block_id: BlockId) {
+        // Self-loops require no tracking (could never introduce more uses).
+        if source_block_id == target_block_id {
+            return;
+        }
+
+        // FIXME(eddyb) is this necessary? (the concern is that dirty-tracking
+        // might get confused, but it shouldn't actually be an issue)
+        self.propagate();
+
+        let [source_block_idx, target_block_idx] = [source_block_id, target_block_id]
+            .map(|block_id| BlockIdx(self.def_map.blocks_by_id.get_index_of(&block_id).unwrap()));
+
+        if self.blocks[target_block_idx].preds.insert(source_block_idx) {
+            self.add_uses_to(
+                source_block_idx,
+                AddUsesSource::PropagateBackwardsAcrossEdge {
+                    target: target_block_idx,
+                    only_dirty: false,
+                },
+            );
+        }
+    }
+
+    fn propagate(&mut self) {
+        while let Some(block_idx) = self.propagate_queue.pop_front() {
+            for i in 0..self.blocks[block_idx].preds.len() {
+                let pred_block_idx = self.blocks[block_idx].preds[i];
+
+                self.add_uses_to(
+                    pred_block_idx,
+                    AddUsesSource::PropagateBackwardsAcrossEdge {
+                        target: block_idx,
+                        only_dirty: true,
+                    },
+                );
+            }
+            self.blocks[block_idx].dirty_chunks.clear();
+        }
+    }
+
+    fn add_uses_to(&mut self, block_idx: BlockIdx, uses: AddUsesSource) {
+        // FIXME(eddyb) make this unnecessary for a comparison later, perhaps?
+        let block_id = self.def_map.block_id_from_idx(block_idx);
+
+        let mut new_uses;
+        let (block_acc, chunked_uses) = match uses {
+            AddUsesSource::New(def_idx) => {
+                new_uses = data::FixedBitSet::new();
+                new_uses.insert(def_idx.0 % CHUNK_SIZE, ());
+                (
+                    &mut self.blocks[block_idx],
+                    Either::Left([(def_idx.chunk(), &new_uses)].into_iter()),
+                )
+            }
+            AddUsesSource::PropagateBackwardsAcrossEdge { target, only_dirty } => {
+                let [block_acc, target_block_acc] =
+                    self.blocks.get_mut2([block_idx, target]).unwrap();
+
+                (
+                    block_acc,
+                    Either::Right(if only_dirty {
+                        Either::Left(target_block_acc.dirty_chunks.iter().map(|(chunk_idx, _)| {
+                            (chunk_idx, target_block_acc.uses.get(chunk_idx).unwrap())
+                        }))
+                    } else {
+                        Either::Right(target_block_acc.uses.iter())
+                    }),
+                )
+            }
+        };
+
+        let block_was_dirty = !block_acc.dirty_chunks.is_empty();
+        for (chunk_idx, new_uses) in chunked_uses {
+            // Use tracking terminates in the defining block.
+            if self.def_map.chunk_to_block_id[chunk_idx] == block_id {
+                continue;
+            }
+
+            let uses = block_acc.uses.entry(chunk_idx).or_default();
+
+            let old_and_new_uses = uses.union(new_uses);
+            if *uses != old_and_new_uses {
+                *uses = old_and_new_uses;
+                block_acc.dirty_chunks.entry(chunk_idx).insert(());
+            }
+        }
+        if !block_was_dirty && !block_acc.dirty_chunks.is_empty() {
+            self.propagate_queue.push_back(block_idx);
+        }
+    }
+}
+
+// HACK(eddyb) the hierarchy/breadth/sparsity/etc. of these data structures is
+// somewhat arbitrary, but they should do better than naive non-sparse solutions.
+// FIMXE(eddyb) attempt to fine-tune this for realistic workloads.
+// FIXME(eddyb) move this out of here.
+mod data {
+    use smallvec::SmallVec;
+    use std::marker::PhantomData;
+    use std::{iter, mem, ops};
+
+    // FIXME(eddyb) should this be `FlatVec`? also, does it belong here?
+    pub struct KeyedVec<K, T> {
+        vec: Vec<T>,
+        _marker: PhantomData<K>,
+    }
+
+    impl<K: Copy + Into<usize> + From<usize>, T> Default for KeyedVec<K, T> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+    impl<K: Copy + Into<usize> + From<usize>, T> KeyedVec<K, T> {
+        pub fn new() -> Self {
+            Self { vec: vec![], _marker: PhantomData }
+        }
+        pub fn from_fn(keys: ops::RangeTo<K>, mut f: impl FnMut(K) -> T) -> Self {
+            KeyedVec {
+                vec: (0..keys.end.into()).map(|i| f(K::from(i))).collect(),
+                _marker: PhantomData,
+            }
+        }
+        pub fn push(&mut self, x: T) -> K {
+            let k = K::from(self.vec.len());
+            self.vec.push(x);
+            k
+        }
+        pub fn into_iter(self) -> impl Iterator<Item = (K, T)> {
+            self.vec.into_iter().enumerate().map(|(i, x)| (K::from(i), x))
+        }
+
+        // FIXME(eddyb) replace this when `get_many_mut` gets stabilizes.
+        pub fn get_mut2(&mut self, keys: [K; 2]) -> Option<[&mut T; 2]> {
+            let [k_i, k_j] = keys;
+            let (i, j) = (k_i.into(), k_j.into());
+            if i > j {
+                let [y, x] = self.get_mut2([k_j, k_i])?;
+                return Some([x, y]);
+            }
+            if i == j || j >= self.vec.len() {
+                return None;
+            }
+
+            let (xs, ys) = self.vec.split_at_mut(j);
+            Some([&mut xs[i], &mut ys[0]])
+        }
+    }
+    impl<K: Copy + Into<usize> + From<usize>, T> ops::Index<K> for KeyedVec<K, T> {
+        type Output = T;
+        fn index(&self, k: K) -> &T {
+            &self.vec[k.into()]
+        }
+    }
+    impl<K: Copy + Into<usize> + From<usize>, T> ops::IndexMut<K> for KeyedVec<K, T> {
+        fn index_mut(&mut self, k: K) -> &mut T {
+            &mut self.vec[k.into()]
+        }
+    }
+
+    // HACK(eddyb) abstraction to enable code sharing between maps and sets.
+    pub trait ValueStorage<V> {
+        // HACK(eddyb) most of the need for this arises from avoidance of
+        // `unsafe` code (i.e. `MaybeUninit<V>` could suffice in most cases).
+        type Slot: Default;
+        fn slot_unwrap(slot: Self::Slot) -> V;
+        fn slot_unwrap_ref(slot: &Self::Slot) -> &V;
+        fn slot_unwrap_mut(slot: &mut Self::Slot) -> &mut V;
+        fn slot_insert(slot: &mut Self::Slot, v: V) -> &mut V;
+
+        // FIXME(eddyb) ideally whether this allocates would be size-based.
+        // FIXME(eddyb) the name and APIs probably don't make it clear this is
+        // for holding some number of `Self::Slot`s specifically.
+        type LazyBox<T>;
+        fn lazy_box_default<T>(default: impl Fn() -> T) -> Self::LazyBox<T>;
+        fn lazy_box_unwrap_ref<T>(lb: &Self::LazyBox<T>) -> &T;
+        fn lazy_box_unwrap_mut_or_alloc<T>(
+            lb: &mut Self::LazyBox<T>,
+            default: impl Fn() -> T,
+        ) -> &mut T;
+    }
+
+    pub enum IgnoreValue {}
+    impl ValueStorage<()> for IgnoreValue {
+        type Slot = ();
+        fn slot_unwrap(_: ()) {}
+        fn slot_unwrap_ref(_: &()) -> &() {
+            &()
+        }
+        fn slot_unwrap_mut(slot: &mut ()) -> &mut () {
+            slot
+        }
+        fn slot_insert(slot: &mut (), _: ()) -> &mut () {
+            slot
+        }
+
+        type LazyBox<T> = T;
+        fn lazy_box_default<T>(default: impl Fn() -> T) -> T {
+            default()
+        }
+        fn lazy_box_unwrap_ref<T>(lb: &T) -> &T {
+            lb
+        }
+        fn lazy_box_unwrap_mut_or_alloc<T>(lb: &mut T, _: impl Fn() -> T) -> &mut T {
+            lb
+        }
+    }
+
+    pub enum EfficientValue {}
+    impl<V: Default> ValueStorage<V> for EfficientValue {
+        type Slot = V;
+        fn slot_unwrap(slot: V) -> V {
+            slot
+        }
+        fn slot_unwrap_ref(slot: &V) -> &V {
+            slot
+        }
+        fn slot_unwrap_mut(slot: &mut V) -> &mut V {
+            slot
+        }
+        fn slot_insert(slot: &mut V, v: V) -> &mut V {
+            *slot = v;
+            slot
+        }
+
+        // FIXME(eddyb) this is far from "efficient", maybe this part belong
+        // in another `trait`, or some better automation could be found?
+        type LazyBox<T> = Option<Box<T>>;
+        fn lazy_box_default<T>(_: impl Fn() -> T) -> Option<Box<T>> {
+            None
+        }
+        fn lazy_box_unwrap_ref<T>(lb: &Option<Box<T>>) -> &T {
+            lb.as_deref().unwrap()
+        }
+        fn lazy_box_unwrap_mut_or_alloc<T>(
+            lb: &mut Option<Box<T>>,
+            default: impl Fn() -> T,
+        ) -> &mut T {
+            lb.get_or_insert_with(|| Box::new(default()))
+        }
+    }
+
+    // HACK(eddyb) most of the need for this arises from avoidance of
+    // `unsafe` code (i.e. `MaybeUninit<V>` could suffice in most cases).
+    pub enum WrapNonDefaultValueInOption {}
+    impl<V> ValueStorage<V> for WrapNonDefaultValueInOption {
+        type Slot = Option<V>;
+        fn slot_unwrap(slot: Option<V>) -> V {
+            slot.unwrap()
+        }
+        fn slot_unwrap_ref(slot: &Option<V>) -> &V {
+            slot.as_ref().unwrap()
+        }
+        fn slot_unwrap_mut(slot: &mut Option<V>) -> &mut V {
+            slot.as_mut().unwrap()
+        }
+        fn slot_insert(slot: &mut Option<V>, v: V) -> &mut V {
+            slot.insert(v)
+        }
+
+        type LazyBox<T> = Option<Box<T>>;
+        fn lazy_box_default<T>(_: impl Fn() -> T) -> Option<Box<T>> {
+            None
+        }
+        fn lazy_box_unwrap_ref<T>(lb: &Option<Box<T>>) -> &T {
+            lb.as_deref().unwrap()
+        }
+        fn lazy_box_unwrap_mut_or_alloc<T>(
+            lb: &mut Option<Box<T>>,
+            default: impl Fn() -> T,
+        ) -> &mut T {
+            lb.get_or_insert_with(|| Box::new(default()))
+        }
+    }
+
+    // FIXME(eddyb) maybe make this parameterizable?
+    type FixedBitSetUint = u64;
+
+    pub type FixedBitSet<K> = FixedFlatMap<K, (), IgnoreValue>;
+    const _: () =
+        assert!(mem::size_of::<FixedBitSet<usize>>() == mem::size_of::<FixedBitSetUint>());
+
+    pub struct FixedFlatMap<K, V, VS: ValueStorage<V> = EfficientValue> {
+        occupied: FixedBitSetUint,
+        slots: VS::LazyBox<[VS::Slot; FixedBitSet::SIZE]>,
+        _marker: PhantomData<K>,
+    }
+
+    impl FixedBitSet<usize> {
+        pub const SIZE: usize = {
+            let bit_width = mem::size_of::<FixedBitSetUint>() * 8;
+            assert!(FixedBitSetUint::count_ones(!0) == bit_width as u32);
+            bit_width
+        };
+    }
+    impl<K> PartialEq for FixedBitSet<K> {
+        fn eq(&self, other: &Self) -> bool {
+            self.occupied == other.occupied
+        }
+    }
+    impl<K: Copy + Into<usize> + From<usize>> FixedBitSet<K> {
+        pub fn union(&self, other: &Self) -> Self {
+            Self { occupied: self.occupied | other.occupied, ..Self::default() }
+        }
+    }
+
+    impl<K: Copy + Into<usize> + From<usize>, V, VS: ValueStorage<V>> Default
+        for FixedFlatMap<K, V, VS>
+    {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+    impl<K: Copy + Into<usize> + From<usize>, V, VS: ValueStorage<V>> FixedFlatMap<K, V, VS> {
+        pub fn new() -> Self {
+            Self {
+                occupied: 0,
+                slots: VS::lazy_box_default(|| std::array::from_fn(|_| Default::default())),
+                _marker: PhantomData,
+            }
+        }
+        pub fn contains(&self, k: K) -> bool {
+            u32::try_from(k.into()).ok().and_then(|k| Some(self.occupied.checked_shr(k)? & 1))
+                == Some(1)
+        }
+        pub fn get(&self, k: K) -> Option<&V> {
+            self.contains(k)
+                .then(|| VS::slot_unwrap_ref(&VS::lazy_box_unwrap_ref(&self.slots)[k.into()]))
+        }
+        pub fn entry(&mut self, k: K) -> FixedFlatMapEntry<'_, V, VS> {
+            let k = k.into();
+            let key_mask = FixedBitSetUint::checked_shl(1, u32::try_from(k).unwrap()).unwrap();
+            FixedFlatMapEntry {
+                key_mask,
+                occupied: &mut self.occupied,
+                slot: &mut VS::lazy_box_unwrap_mut_or_alloc(&mut self.slots, || {
+                    std::array::from_fn(|_| Default::default())
+                })[k],
+            }
+        }
+
+        pub fn insert(&mut self, k: K, v: V) {
+            self.entry(k).insert(v);
+        }
+        fn remove(&mut self, k: K) -> Option<V> {
+            self.contains(k).then(|| self.entry(k).remove().unwrap())
+        }
+
+        pub fn keys(&self) -> impl Iterator<Item = K> {
+            let mut i = 0;
+            let mut remaining = self.occupied;
+            iter::from_fn(move || {
+                (remaining != 0).then(|| {
+                    let gap = remaining.trailing_zeros() as usize;
+                    i += gap;
+                    remaining >>= gap;
+
+                    let k = K::from(i);
+
+                    // Skip the lowest bit (which should always be `1` here).
+                    i += 1;
+                    remaining >>= 1;
+
+                    k
+                })
+            })
+        }
+        pub fn iter(&self) -> impl Iterator<Item = (K, &V)> + '_ {
+            self.keys().map(|k| (k, self.get(k).unwrap()))
+        }
+        pub fn drain(&mut self) -> impl Iterator<Item = (K, V)> + '_ {
+            self.keys().map(|k| (k, self.remove(k).unwrap()))
+        }
+
+        // FIXME(eddyb) does this fully replace `drain`?
+        pub fn clear(&mut self) {
+            // FIXME(eddyb) theoretically this could be more efficient, but
+            // it doesn't seem worth it wrt `VS` abstraction complexity.
+            for _ in self.drain() {}
+        }
+    }
+
+    pub struct FixedFlatMapEntry<'a, V, VS: ValueStorage<V> = EfficientValue> {
+        key_mask: FixedBitSetUint,
+        occupied: &'a mut FixedBitSetUint,
+        // FIXME(eddyb) in theory, this forces the `Box` to be allocated even
+        // when it might not be needed, so it optimizes for e.g. insertion.
+        slot: &'a mut VS::Slot,
+    }
+
+    impl<'a, V, VS: ValueStorage<V>> FixedFlatMapEntry<'a, V, VS> {
+        pub fn occupied(&self) -> bool {
+            (*self.occupied & self.key_mask) != 0
+        }
+        fn into_mut(self) -> Option<&'a mut V> {
+            self.occupied().then(|| VS::slot_unwrap_mut(self.slot))
+        }
+        pub fn or_insert_with(self, f: impl FnOnce() -> V) -> &'a mut V {
+            if self.occupied() { self.into_mut().unwrap() } else { self.insert(f()) }
+        }
+        pub fn insert(self, v: V) -> &'a mut V {
+            *self.occupied |= self.key_mask;
+            VS::slot_insert(self.slot, v)
+        }
+        pub fn remove(&mut self) -> Option<V> {
+            self.occupied().then(|| {
+                *self.occupied &= !self.key_mask;
+                VS::slot_unwrap(mem::take(self.slot))
+            })
+        }
+    }
+
+    // FIXME(eddyb) not a sparse bitset because of how `SparseMap` is only sparse
+    // wrt not allocating space to store values until needed, but `BitSet` has no
+    // real values (and uses `IgnoreValue` to completely remove that allocation).
+    pub type BitSet<K> = SparseMap<K, (), IgnoreValue>;
+
+    pub struct SparseMap<K, V, VS: ValueStorage<V> = EfficientValue> {
+        // NOTE(eddyb) this is really efficient when the keys don't exceed
+        // `FixedBitSet::SIZE`, and this can be further amplified by using
+        // e.g. `SparseMap<_, FixedFlatMap<_, V>>`, which adds another layer
+        // of sparseness (more concretely, if `FixedBitSet::SIZE == 64`, then
+        // that combination can effectively handle up to 64*64 = 4096 entries
+        // without causing the outermost `SmallFlatMap` to allocate a `Vec`).
+        outer_map: SmallVec<[FixedFlatMap<usize, V, VS>; 1]>,
+        count: usize,
+        _marker: PhantomData<K>,
+    }
+
+    impl<K: Copy + Into<usize> + From<usize>, V, VS: ValueStorage<V>> Default for SparseMap<K, V, VS> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+    impl<K: Copy + Into<usize> + From<usize>, V, VS: ValueStorage<V>> SparseMap<K, V, VS> {
+        pub fn new() -> Self {
+            Self { outer_map: SmallVec::new(), count: 0, _marker: PhantomData }
+        }
+        pub fn is_empty(&self) -> bool {
+            self.count == 0
+        }
+        pub fn get(&self, k: K) -> Option<&V> {
+            let k = k.into();
+            let (outer_key, inner_key) = (k / FixedBitSet::SIZE, k % FixedBitSet::SIZE);
+            self.outer_map.get(outer_key)?.get(inner_key)
+        }
+        pub fn entry(&mut self, k: K) -> SparseMapEntry<'_, V, VS> {
+            let k = k.into();
+            let (outer_key, inner_key) = (k / FixedBitSet::SIZE, k % FixedBitSet::SIZE);
+            let needed_outer_len = outer_key + 1;
+            if self.outer_map.len() < needed_outer_len {
+                self.outer_map.resize_with(needed_outer_len, Default::default);
+            }
+            SparseMapEntry {
+                inner: self.outer_map[outer_key].entry(inner_key),
+                count: &mut self.count,
+            }
+        }
+
+        pub fn iter(&self) -> impl Iterator<Item = (K, &V)> + '_ {
+            (!self.is_empty())
+                .then(|| {
+                    self.outer_map.iter().enumerate().flat_map(|(outer_key, inner_map)| {
+                        inner_map.iter().map(move |(inner_key, v)| {
+                            (K::from(outer_key * FixedBitSet::SIZE + inner_key), v)
+                        })
+                    })
+                })
+                .into_iter()
+                .flatten()
+        }
+
+        pub fn clear(&mut self) {
+            for inner_map in &mut self.outer_map {
+                inner_map.clear();
+            }
+            self.count = 0;
+        }
+    }
+
+    pub struct SparseMapEntry<'a, V, VS: ValueStorage<V> = EfficientValue> {
+        inner: FixedFlatMapEntry<'a, V, VS>,
+        count: &'a mut usize,
+    }
+
+    impl<'a, V, VS: ValueStorage<V>> SparseMapEntry<'a, V, VS> {
+        pub fn or_insert_with(self, f: impl FnOnce() -> V) -> &'a mut V {
+            self.inner.or_insert_with(|| {
+                *self.count += 1;
+                f()
+            })
+        }
+        #[allow(clippy::unwrap_or_default)]
+        pub fn or_default(self) -> &'a mut V
+        where
+            V: Default,
+        {
+            self.or_insert_with(V::default)
+        }
+        pub fn insert(self, v: V) {
+            if !self.inner.occupied() {
+                *self.count += 1;
+            }
+            self.inner.insert(v);
+        }
+    }
+}

--- a/src/cfgssa.rs
+++ b/src/cfgssa.rs
@@ -228,13 +228,10 @@ impl<'a, BlockId: Copy + Eq + Hash, DefId: Copy + Eq + Hash, DefType: Copy>
             .map(|block_id| BlockIdx(self.def_map.blocks_by_id.get_index_of(&block_id).unwrap()));
 
         if self.blocks[target_block_idx].preds.insert(source_block_idx) {
-            self.add_uses_to(
-                source_block_idx,
-                AddUsesSource::PropagateBackwardsAcrossEdge {
-                    target: target_block_idx,
-                    only_dirty: false,
-                },
-            );
+            self.add_uses_to(source_block_idx, AddUsesSource::PropagateBackwardsAcrossEdge {
+                target: target_block_idx,
+                only_dirty: false,
+            });
         }
     }
 
@@ -243,13 +240,10 @@ impl<'a, BlockId: Copy + Eq + Hash, DefId: Copy + Eq + Hash, DefType: Copy>
             for i in 0..self.blocks[block_idx].preds.len() {
                 let pred_block_idx = self.blocks[block_idx].preds[i];
 
-                self.add_uses_to(
-                    pred_block_idx,
-                    AddUsesSource::PropagateBackwardsAcrossEdge {
-                        target: block_idx,
-                        only_dirty: true,
-                    },
-                );
+                self.add_uses_to(pred_block_idx, AddUsesSource::PropagateBackwardsAcrossEdge {
+                    target: block_idx,
+                    only_dirty: true,
+                });
             }
             self.blocks[block_idx].dirty_chunks.clear();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -829,6 +829,19 @@ pub enum ControlNodeKind {
         // have any ambiguity as to whether it can see `body`-computed values)
         repeat_condition: Value,
     },
+
+    /// Leave the current invocation, similar to returning from every function
+    /// call in the stack (up to and including the entry-point), but potentially
+    /// indicating a fatal error as well.
+    //
+    // FIXME(eddyb) make this less shader-controlflow-centric.
+    ExitInvocation {
+        kind: cfg::ExitInvocationKind,
+
+        // FIXME(eddyb) centralize `Value` inputs across `ControlNode`s,
+        // and only use stricter types for building/traversing the IR.
+        inputs: SmallVec<[Value; 2]>,
+    },
 }
 
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -884,7 +884,7 @@ pub enum DataInstKind {
     },
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Value {
     Const(Const),
 

--- a/src/passes/legalize.rs
+++ b/src/passes/legalize.rs
@@ -1,6 +1,6 @@
 use crate::visit::{InnerVisit, Visitor};
 use crate::{
-    cfg, AttrSet, Const, Context, DataInstForm, DeclDef, Func, FxIndexSet, GlobalVar, Module, Type,
+    AttrSet, Const, Context, DataInstForm, DeclDef, Func, FxIndexSet, GlobalVar, Module, Type, cfg,
 };
 
 /// Apply the [`cfg::Structurizer`] algorithm to all function definitions in `module`.

--- a/src/passes/qptr.rs
+++ b/src/passes/qptr.rs
@@ -1,8 +1,8 @@
 //! [`QPtr`](crate::TypeKind::QPtr) transforms.
 
 use crate::visit::{InnerVisit, Visitor};
-use crate::{qptr, DataInstForm};
 use crate::{AttrSet, Const, Context, Func, FxIndexSet, GlobalVar, Module, Type};
+use crate::{DataInstForm, qptr};
 
 pub fn lower_from_spv_ptrs(module: &mut Module, layout_config: &qptr::LayoutConfig) {
     let cx = &module.cx();

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -3053,6 +3053,15 @@ impl Print for FuncAt<'_, ControlNode> {
                     repeat_condition.print(printer),
                 ])
             }
+            ControlNodeKind::ExitInvocation {
+                kind: cfg::ExitInvocationKind::SpvInst(spv::Inst { opcode, imms }),
+                inputs,
+            } => printer.pretty_spv_inst(
+                kw_style,
+                *opcode,
+                imms,
+                inputs.iter().map(|v| v.print(printer)),
+            ),
         };
         pretty::Fragment::new([
             Use::AlignmentAnchorForControlNode(self.position).print_as_def(printer),

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -24,13 +24,13 @@ use crate::print::multiversion::Versions;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::visit::{InnerVisit, Visit, Visitor};
 use crate::{
-    cfg, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context,
-    ControlNode, ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion,
-    ControlRegionDef, ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef,
-    DataInstKind, DeclDef, Diag, DiagLevel, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func,
-    FuncDecl, FuncParam, FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDecl, GlobalVarDefBody,
-    Import, Module, ModuleDebugInfo, ModuleDialect, OrdAssertEq, SelectionKind, Type, TypeDef,
-    TypeKind, TypeOrConst, Value,
+    AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, ControlNode,
+    ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionDef,
+    ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef, DataInstKind,
+    DeclDef, Diag, DiagLevel, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func, FuncDecl,
+    FuncParam, FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDecl, GlobalVarDefBody, Import, Module,
+    ModuleDebugInfo, ModuleDialect, OrdAssertEq, SelectionKind, Type, TypeDef, TypeKind,
+    TypeOrConst, Value, cfg, spv,
 };
 use arrayvec::ArrayVec;
 use itertools::Either;
@@ -1839,10 +1839,9 @@ impl Print for spv::Dialect {
                             printer.pretty_spv_print_tokens_for_operand({
                                 let mut tokens = spv::print::operand_from_imms(cap_imms(cap));
                                 tokens.tokens.drain(..tokens.tokens.len() - 1);
-                                assert!(matches!(
-                                    tokens.tokens[..],
-                                    [spv::print::Token::EnumerandName(_)]
-                                ));
+                                assert!(matches!(tokens.tokens[..], [
+                                    spv::print::Token::EnumerandName(_)
+                                ]));
                                 tokens
                             })
                         });
@@ -1971,12 +1970,8 @@ impl Print for spv::ModuleDebugInfo {
                                                             printer.pretty_string_literal(
                                                                 &printer.cx[file],
                                                             ),
-                                                            pretty::join_space(
-                                                                ":",
-                                                                [printer.pretty_string_literal(
-                                                                    contents,
-                                                                )],
-                                                            ),
+                                                            pretty::join_space(":", [printer
+                                                                .pretty_string_literal(contents)]),
                                                         ])
                                                     })
                                                     .map(|entry| {
@@ -2999,13 +2994,10 @@ impl Print for FuncAt<'_, ControlNode> {
                 let (inputs_header, body_suffix) = if !inputs.is_empty() {
                     let input_decls_and_uses =
                         inputs.iter().enumerate().map(|(input_idx, input)| {
-                            (
-                                input,
-                                Value::ControlRegionInput {
-                                    region: *body,
-                                    input_idx: input_idx.try_into().unwrap(),
-                                },
-                            )
+                            (input, Value::ControlRegionInput {
+                                region: *body,
+                                input_idx: input_idx.try_into().unwrap(),
+                            })
                         });
                     (
                         pretty::join_comma_sep(

--- a/src/print/multiversion.rs
+++ b/src/print/multiversion.rs
@@ -1,7 +1,7 @@
 //! Multi-version pretty-printing support (e.g. for comparing the IR between passes).
 
-use crate::print::pretty::{self, TextOp};
 use crate::FxIndexMap;
+use crate::print::pretty::{self, TextOp};
 use internal_iterator::{
     FromInternalIterator, InternalIterator, IntoInternalIterator, IteratorExt,
 };

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -1,9 +1,9 @@
 //! [`QPtr`](crate::TypeKind::QPtr) usage analysis (for legalizing/lifting).
 
 // HACK(eddyb) sharing layout code with other modules.
-use super::{layout::*, QPtrMemUsageKind};
+use super::{QPtrMemUsageKind, layout::*};
 
-use super::{shapes, QPtrAttr, QPtrMemUsage, QPtrOp, QPtrUsage};
+use super::{QPtrAttr, QPtrMemUsage, QPtrOp, QPtrUsage, shapes};
 use crate::func_at::FuncAt;
 use crate::visit::{InnerVisit, Visitor};
 use crate::{

--- a/src/qptr/layout.rs
+++ b/src/qptr/layout.rs
@@ -2,7 +2,7 @@
 
 use crate::qptr::shapes;
 use crate::{
-    spv, AddrSpace, Attr, Const, ConstKind, Context, Diag, FxIndexMap, Type, TypeKind, TypeOrConst,
+    AddrSpace, Attr, Const, ConstKind, Context, Diag, FxIndexMap, Type, TypeKind, TypeOrConst, spv,
 };
 use itertools::Either;
 use smallvec::SmallVec;

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -4,13 +4,13 @@
 use super::layout::*;
 
 use crate::func_at::FuncAtMut;
-use crate::qptr::{shapes, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
+use crate::qptr::{QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage, shapes};
 use crate::transform::{InnerInPlaceTransform, InnerTransform, Transformed, Transformer};
 use crate::{
-    spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, ControlNode,
+    AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, ControlNode,
     ControlNodeKind, DataInst, DataInstDef, DataInstFormDef, DataInstKind, DeclDef, Diag,
     DiagLevel, EntityDefs, EntityOrientedDenseMap, Func, FuncDecl, FxIndexMap, GlobalVar,
-    GlobalVarDecl, Module, Type, TypeDef, TypeKind, TypeOrConst, Value,
+    GlobalVarDecl, Module, Type, TypeDef, TypeKind, TypeOrConst, Value, spv,
 };
 use smallvec::SmallVec;
 use std::cell::Cell;
@@ -520,15 +520,12 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                     _ => return Err(LiftError(Diag::bug(["non-Buffer pointee".into()]))),
                 };
 
-                self.deferred_ptr_noops.insert(
-                    data_inst,
-                    DeferredPtrNoop {
-                        output_pointer: buf_ptr,
-                        output_pointer_addr_space: addr_space,
-                        output_pointee_layout: buf_data_layout,
-                        parent_block,
-                    },
-                );
+                self.deferred_ptr_noops.insert(data_inst, DeferredPtrNoop {
+                    output_pointer: buf_ptr,
+                    output_pointer_addr_space: addr_space,
+                    output_pointee_layout: buf_data_layout,
+                    parent_block,
+                });
 
                 DataInstDef {
                     // FIXME(eddyb) avoid the repeated call to `type_of_val`
@@ -557,10 +554,10 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                                 last_field.mem_layout.fixed_base.size == 0
                                     && last_field.mem_layout.dyn_unit_stride
                                         == Some(dyn_unit_stride)
-                                    && matches!(
-                                        last_field.components,
-                                        Components::Elements { fixed_len: None, .. }
-                                    )
+                                    && matches!(last_field.components, Components::Elements {
+                                        fixed_len: None,
+                                        ..
+                                    })
                             }) =>
                     {
                         u32::try_from(offsets.len() - 1).unwrap()
@@ -660,15 +657,12 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                 }
 
                 if access_chain_inputs.len() == 1 {
-                    self.deferred_ptr_noops.insert(
-                        data_inst,
-                        DeferredPtrNoop {
-                            output_pointer: base_ptr,
-                            output_pointer_addr_space: addr_space,
-                            output_pointee_layout: TypeLayout::Concrete(layout),
-                            parent_block,
-                        },
-                    );
+                    self.deferred_ptr_noops.insert(data_inst, DeferredPtrNoop {
+                        output_pointer: base_ptr,
+                        output_pointer_addr_space: addr_space,
+                        output_pointee_layout: TypeLayout::Concrete(layout),
+                        parent_block,
+                    });
                     DataInstDef {
                         // FIXME(eddyb) avoid the repeated call to `type_of_val`
                         // (and the interning of a temporary `DataInstFormDef`),

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -4,12 +4,12 @@
 use super::layout::*;
 
 use crate::func_at::FuncAtMut;
-use crate::qptr::{shapes, QPtrAttr, QPtrOp};
+use crate::qptr::{QPtrAttr, QPtrOp, shapes};
 use crate::transform::{InnerInPlaceTransform, Transformed, Transformer};
 use crate::{
-    spv, AddrSpace, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, ControlNode,
+    AddrSpace, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, ControlNode,
     ControlNodeKind, DataInst, DataInstDef, DataInstForm, DataInstFormDef, DataInstKind, Diag,
-    FuncDecl, GlobalVarDecl, OrdAssertEq, Type, TypeKind, TypeOrConst, Value,
+    FuncDecl, GlobalVarDecl, OrdAssertEq, Type, TypeKind, TypeOrConst, Value, spv,
 };
 use smallvec::SmallVec;
 use std::cell::Cell;

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -466,7 +466,7 @@ impl<'a> FuncAt<'a, ControlRegion> {
     /// and being able to stop iteration by returning `Err`.
     ///
     /// RPO iteration over a CFG provides certain guarantees, most importantly
-    /// that SSA definitions are visited before any of their uses.
+    /// that dominators are visited before the entire subgraph they dominate.
     fn rev_post_order_try_for_each<E>(
         self,
         mut f: impl FnMut(CfgCursor<'_>) -> Result<(), E>,

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -4,12 +4,12 @@ use crate::func_at::FuncAt;
 use crate::spv::{self, spec};
 use crate::visit::{InnerVisit, Visitor};
 use crate::{
-    cfg, AddrSpace, Attr, AttrSet, Const, ConstDef, ConstKind, Context, ControlNode,
-    ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionInputDecl, DataInst,
-    DataInstDef, DataInstForm, DataInstFormDef, DataInstKind, DeclDef, EntityList, ExportKey,
-    Exportee, Func, FuncDecl, FuncParam, FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDefBody,
-    Import, Module, ModuleDebugInfo, ModuleDialect, SelectionKind, Type, TypeDef, TypeKind,
-    TypeOrConst, Value,
+    AddrSpace, Attr, AttrSet, Const, ConstDef, ConstKind, Context, ControlNode, ControlNodeKind,
+    ControlNodeOutputDecl, ControlRegion, ControlRegionInputDecl, DataInst, DataInstDef,
+    DataInstForm, DataInstFormDef, DataInstKind, DeclDef, EntityList, ExportKey, Exportee, Func,
+    FuncDecl, FuncParam, FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDefBody, Import, Module,
+    ModuleDebugInfo, ModuleDialect, SelectionKind, Type, TypeDef, TypeKind, TypeOrConst, Value,
+    cfg,
 };
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
@@ -484,10 +484,10 @@ impl<'a> FuncAt<'a, ControlRegion> {
         let region = self.position;
         f(CfgCursor { point: CfgPoint::RegionEntry(region), parent })?;
         for func_at_control_node in self.at_children() {
-            func_at_control_node.rev_post_order_try_for_each_inner(
-                f,
-                &CfgCursor { point: ControlParent::Region(region), parent },
-            )?;
+            func_at_control_node.rev_post_order_try_for_each_inner(f, &CfgCursor {
+                point: ControlParent::Region(region),
+                parent,
+            })?;
         }
         f(CfgCursor { point: CfgPoint::RegionExit(region), parent })
     }
@@ -907,17 +907,14 @@ impl<'a> FuncLifting<'a> {
                     // they start being tracked.
                     if target_phis.is_empty() {
                         let extra_insts = mem::take(extra_insts);
-                        let new_terminator = mem::replace(
-                            new_terminator,
-                            Terminator {
-                                attrs: Default::default(),
-                                kind: Cow::Owned(cfg::ControlInstKind::Unreachable),
-                                inputs: Default::default(),
-                                targets: Default::default(),
-                                target_phi_values: Default::default(),
-                                merge: None,
-                            },
-                        );
+                        let new_terminator = mem::replace(new_terminator, Terminator {
+                            attrs: Default::default(),
+                            kind: Cow::Owned(cfg::ControlInstKind::Unreachable),
+                            inputs: Default::default(),
+                            targets: Default::default(),
+                            target_phi_values: Default::default(),
+                            merge: None,
+                        });
                         *target_use_count = 0;
 
                         let combined_block = &mut blocks[block_idx];

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -846,13 +846,10 @@ impl Spec {
                     bases[0] = "LiteralContextDependentNumber";
                 }
 
-                (
-                    o.kind,
-                    [
-                        operand_kinds.lookup(bases[0]).unwrap(),
-                        operand_kinds.lookup(bases[1]).unwrap(),
-                    ],
-                )
+                (o.kind, [
+                    operand_kinds.lookup(bases[0]).unwrap(),
+                    operand_kinds.lookup(bases[1]).unwrap(),
+                ])
             })
             .collect();
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -3,12 +3,12 @@
 use crate::func_at::FuncAtMut;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::{
-    cfg, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, ControlNode,
-    ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionDef,
+    AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, ControlNode, ControlNodeDef,
+    ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionDef,
     ControlRegionInputDecl, DataInst, DataInstDef, DataInstForm, DataInstFormDef, DataInstKind,
     DeclDef, EntityListIter, ExportKey, Exportee, Func, FuncDecl, FuncDefBody, FuncParam,
     GlobalVar, GlobalVarDecl, GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect,
-    OrdAssertEq, SelectionKind, Type, TypeDef, TypeKind, TypeOrConst, Value,
+    OrdAssertEq, SelectionKind, Type, TypeDef, TypeKind, TypeOrConst, Value, cfg, spv,
 };
 use std::cmp::Ordering;
 use std::rc::Rc;

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -490,6 +490,14 @@ impl<'a> FuncAt<'a, ControlNode> {
                 visitor.visit_control_region_def(self.at(*body));
                 visitor.visit_value_use(repeat_condition);
             }
+            ControlNodeKind::ExitInvocation {
+                kind: cfg::ExitInvocationKind::SpvInst(_),
+                inputs,
+            } => {
+                for v in inputs {
+                    visitor.visit_value_use(v);
+                }
+            }
         }
         for output in outputs {
             output.inner_visit_with(visitor);

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -3,12 +3,12 @@
 use crate::func_at::FuncAt;
 use crate::qptr::{self, QPtrAttr, QPtrMemUsage, QPtrMemUsageKind, QPtrOp, QPtrUsage};
 use crate::{
-    cfg, spv, AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, ControlNode,
-    ControlNodeDef, ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionDef,
+    AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, ControlNode, ControlNodeDef,
+    ControlNodeKind, ControlNodeOutputDecl, ControlRegion, ControlRegionDef,
     ControlRegionInputDecl, DataInstDef, DataInstForm, DataInstFormDef, DataInstKind, DeclDef,
     DiagMsgPart, EntityListIter, ExportKey, Exportee, Func, FuncDecl, FuncDefBody, FuncParam,
     GlobalVar, GlobalVarDecl, GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect,
-    SelectionKind, Type, TypeDef, TypeKind, TypeOrConst, Value,
+    SelectionKind, Type, TypeDef, TypeKind, TypeOrConst, Value, cfg, spv,
 };
 
 // FIXME(eddyb) `Sized` bound shouldn't be needed but removing it requires


### PR DESCRIPTION
These are a bunch of structurization improvements by @eddyb that mainly improve the way instructions that exit the invocation are handled. This includes `OpKill` (`discard;` in glsl), rust panics and yet to be merged `OpEmitMeshTasksEXT` of task shaders.

## Changelog
```
[PR#2](https://github.com/Rust-GPU/spirt/pull/2) improve structurization of instructions that exit the invocation, like `OpKill` (`discard;` in glsl) and rust panics
```