### PR TITLE
Update `SPIRV-Headers` to match Vulkan SDK 1.3.290.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "khronos-spec/SPIRV-Headers"]
 	path = khronos-spec/SPIRV-Headers
 	url = https://github.com/KhronosGroup/SPIRV-Headers
-	branch = vulkan-sdk-1.3.275
+	branch = vulkan-sdk-1.3.290


### PR DESCRIPTION
*(This won't pass CI until #3 lands)*

Similar to https://github.com/EmbarkStudios/spirt/pull/61, the main reason for the bump is to avoid being stuck behind on definitions in a new release (even when there's not much going on).