### PR TITLE
Fix `clippy::needless_lifetimes` warnings (new in `nightly-2024-10-04`).

### DIFF
--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -91,7 +91,7 @@ impl<'a> Iterator for FuncAt<'a, EntityListIter<DataInst>> {
     }
 }
 
-impl<'a> DoubleEndedIterator for FuncAt<'a, EntityListIter<DataInst>> {
+impl DoubleEndedIterator for FuncAt<'_, EntityListIter<DataInst>> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let (prev, rest) = self.position.split_last(self.data_insts)?;
         self.position = rest;

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1145,7 +1145,7 @@ impl Printer<'_> {
     }
 }
 
-impl<'a> Printer<'a> {
+impl Printer<'_> {
     /// Pretty-print a string literal with escaping and styling.
     //
     // FIXME(eddyb) add methods like this for all styled text (e.g. numeric literals).

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -398,7 +398,7 @@ enum ControlParent {
     ControlNode(ControlNode),
 }
 
-impl<'a, 'p> FuncAt<'a, CfgCursor<'p>> {
+impl<'p> FuncAt<'_, CfgCursor<'p>> {
     /// Return the next [`CfgPoint`] (wrapped in [`CfgCursor`]) in a linear
     /// chain within structured control-flow (i.e. no branching to child regions).
     fn unique_successor(self) -> Option<CfgCursor<'p>> {
@@ -461,7 +461,7 @@ impl<'a, 'p> FuncAt<'a, CfgCursor<'p>> {
     }
 }
 
-impl<'a> FuncAt<'a, ControlRegion> {
+impl FuncAt<'_, ControlRegion> {
     /// Traverse every [`CfgPoint`] (deeply) contained in this [`ControlRegion`],
     /// in reverse post-order (RPO), with `f` receiving each [`CfgPoint`]
     /// in turn (wrapped in [`CfgCursor`], for further traversal flexibility),
@@ -493,7 +493,7 @@ impl<'a> FuncAt<'a, ControlRegion> {
     }
 }
 
-impl<'a> FuncAt<'a, ControlNode> {
+impl FuncAt<'_, ControlNode> {
     fn rev_post_order_try_for_each_inner<E>(
         self,
         f: &mut impl FnMut(CfgCursor<'_>) -> Result<(), E>,


### PR DESCRIPTION
Was left out of https://github.com/Rust-GPU/spirt/pull/3 because they just got added/enabled.