### PR TITLE
Rename `ControlRegion` to just `Region`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ With the initial focus being on [Rust-GPU]'s usecase, various (otherwise desirab
 * "entity" system for e.g. definitions in a module, instructions in a function, etc.
   * disallows iteration in favor of/forcing the use of efficient indexing
 * structured control-flow "regions" inspired by RVSDG, stricter than SPIR-V
-  (see `ControlRegionDef`'s docs for more details)
+  (see `RegionDef`'s docs for more details)
 
 </td><td>
 

--- a/src/cfgssa.rs
+++ b/src/cfgssa.rs
@@ -13,7 +13,7 @@
 //! be taken to preserve the correctness of such implicit dataflow across all
 //! transformations, and it's overall far more fragile than the local dataflow
 //! of e.g. phi nodes (or their alternative "block arguments"), or in SPIR-T's
-//! case, `ControlRegion` inputs and `ControlNode` outputs (inspired by RVSDG,
+//! case, `Region` inputs and `ControlNode` outputs (inspired by RVSDG,
 //! which has even stricter isolation/locality in its regions).
 
 use crate::{FxIndexMap, FxIndexSet};

--- a/src/context.rs
+++ b/src/context.rs
@@ -962,7 +962,7 @@ macro_rules! entities {
 entities! {
     GlobalVar => chunk_size(0x1_0000) crate::GlobalVarDecl,
     Func => chunk_size(0x1_0000) crate::FuncDecl,
-    ControlRegion => chunk_size(0x1000) crate::ControlRegionDef,
+    Region => chunk_size(0x1000) crate::RegionDef,
     ControlNode => chunk_size(0x1000) EntityListNode<ControlNode, crate::ControlNodeDef>,
     DataInst => chunk_size(0x1000) EntityListNode<DataInst, crate::DataInstDef>,
 }

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -783,7 +783,7 @@ impl<'a> InferUsage<'a> {
                     for (v, usage) in usage_or_err_attrs_to_attach {
                         let attrs = match v {
                             Value::Const(_) => unreachable!(),
-                            Value::ControlRegionInput { region, input_idx } => {
+                            Value::RegionInput { region, input_idx } => {
                                 &mut func_def_body.at_mut(region).def().inputs[input_idx as usize]
                                     .attrs
                             }
@@ -879,13 +879,13 @@ impl<'a> InferUsage<'a> {
                             // FIXME(eddyb) may be relevant?
                             _ => unreachable!(),
                         },
-                        Value::ControlRegionInput { region, input_idx }
+                        Value::RegionInput { region, input_idx }
                             if region == func_def_body.body =>
                         {
                             &mut param_usages[input_idx as usize]
                         }
                         // FIXME(eddyb) implement
-                        Value::ControlRegionInput { .. } | Value::ControlNodeOutput { .. } => {
+                        Value::RegionInput { .. } | Value::ControlNodeOutput { .. } => {
                             usage_or_err_attrs_to_attach.push((
                                 ptr,
                                 Err(AnalysisError(Diag::bug(["unsupported φ".into()]))),

--- a/src/qptr/mod.rs
+++ b/src/qptr/mod.rs
@@ -54,7 +54,7 @@ pub enum QPtrAttr {
     },
 
     /// When applied to a `QPtr`-typed `GlobalVar`, `DataInst`,
-    /// `ControlRegionInputDecl` or `ControlNodeOutputDecl`, this tracks all the
+    /// `RegionInputDecl` or `ControlNodeOutputDecl`, this tracks all the
     /// ways in which the pointer may be used (see `QPtrUsage`).
     Usage(OrdAssertEq<QPtrUsage>),
 }


### PR DESCRIPTION
Inspired by some ideas around fusing `ControlNode`+`DataInst` (as just `Node`/`Op`/etc.), and unlike those two there is really no reason to distinguish between "kinds of regions".

---

Also used this as a test of a new `jj` feature which allowed me to rebase **_50_** commits downstream of this painlessly (by preventing the normal propagation of diffs, so each commit could be independently rewritten, and those that haven't been yet would have the opposite rename in their diff):
```sh
sed -i -E 's/Control(Region)/\1/g;s/control_(region)/\1/g' README.md src/**.rs \
  && not rg -i 'control.?region' README.md src && cargo fmt --all && cargo check --all \
  && jj restore --from @ --to @- --restore-descendants && jj next
```
(the new feature being `--restore-descendants`, which could better be described as "firewall descendants (downstream/future commits) from these changes")

`&& jj next` at the end only really handles the "main chain" of changes, so after that was done, replacing it with this, at the start, made it possible to chew through the remaining side commits:
```sh
jj new 'latest(uncontrol-region+:: & diff_contains(regex:"[cC]ontrol.?[rR]egion"))' && 
```