### PR TITLE
"Unintern" `DataInstForm` (inlining its fields back into `DataInstDef`).

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -888,7 +888,6 @@ interners! {
         crate::AttrSetDef,
         crate::TypeDef,
         crate::ConstDef,
-        crate::DataInstFormDef,
     }
 
     // FIXME(eddyb) consider a more uniform naming scheme than the combination
@@ -897,7 +896,6 @@ interners! {
     AttrSet default(crate::AttrSetDef::default()) => crate::AttrSetDef,
     Type => crate::TypeDef,
     Const => crate::ConstDef,
-    DataInstForm => crate::DataInstFormDef,
 }
 
 impl<I: sealed::Interned> InternInCx<I> for I::Def

--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -116,7 +116,7 @@ impl FuncAt<'_, Value> {
             Value::NodeOutput { node, output_idx } => {
                 self.at(node).def().outputs[output_idx as usize].ty
             }
-            Value::DataInstOutput(inst) => cx[self.at(inst).def().form].output_type.unwrap(),
+            Value::DataInstOutput(inst) => self.at(inst).def().output_type.unwrap(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -934,26 +934,10 @@ pub use context::DataInst;
 pub struct DataInstDef {
     pub attrs: AttrSet,
 
-    pub form: DataInstForm,
+    pub kind: DataInstKind,
 
     // FIXME(eddyb) change the inline size of this to fit most instructions.
     pub inputs: SmallVec<[Value; 2]>,
-}
-
-/// Interned handle for a [`DataInstFormDef`](crate::DataInstFormDef)
-/// (a "form", or "template", for [`DataInstDef`](crate::DataInstDef)s).
-pub use context::DataInstForm;
-
-/// "Form" (or "template") definition for [`DataInstFormDef`]s, which includes
-/// most of their common *static* information (notably excluding `attrs`, as
-/// they vary more often due to handling diagnostics, debuginfo, refinement etc.).
-//
-// FIXME(eddyb) now that this is interned, try to find all the code that was
-// working around needing to borrow `DataInstKind`, just because it was owned
-// by a `FuncDefBody` (instead of interned in the `Context`).
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct DataInstFormDef {
-    pub kind: DataInstKind,
 
     pub output_type: Option<Type>,
 }

--- a/src/passes/legalize.rs
+++ b/src/passes/legalize.rs
@@ -1,7 +1,5 @@
 use crate::visit::{InnerVisit, Visitor};
-use crate::{
-    AttrSet, Const, Context, DataInstForm, DeclDef, Func, FxIndexSet, GlobalVar, Module, Type, cfg,
-};
+use crate::{AttrSet, Const, Context, DeclDef, Func, FxIndexSet, GlobalVar, Module, Type, cfg};
 
 /// Apply the [`cfg::Structurizer`] algorithm to all function definitions in `module`.
 pub fn structurize_func_cfgs(module: &mut Module) {
@@ -14,7 +12,6 @@ pub fn structurize_func_cfgs(module: &mut Module) {
 
         seen_types: FxIndexSet::default(),
         seen_consts: FxIndexSet::default(),
-        seen_data_inst_forms: FxIndexSet::default(),
         seen_global_vars: FxIndexSet::default(),
         seen_funcs: FxIndexSet::default(),
     };
@@ -37,7 +34,6 @@ struct ReachableUseCollector<'a> {
     // FIXME(eddyb) build some automation to avoid ever repeating these.
     seen_types: FxIndexSet<Type>,
     seen_consts: FxIndexSet<Const>,
-    seen_data_inst_forms: FxIndexSet<DataInstForm>,
     seen_global_vars: FxIndexSet<GlobalVar>,
     seen_funcs: FxIndexSet<Func>,
 }
@@ -55,11 +51,6 @@ impl Visitor<'_> for ReachableUseCollector<'_> {
     fn visit_const_use(&mut self, ct: Const) {
         if self.seen_consts.insert(ct) {
             self.visit_const_def(&self.cx[ct]);
-        }
-    }
-    fn visit_data_inst_form_use(&mut self, data_inst_form: DataInstForm) {
-        if self.seen_data_inst_forms.insert(data_inst_form) {
-            self.visit_data_inst_form_def(&self.cx[data_inst_form]);
         }
     }
 

--- a/src/passes/qptr.rs
+++ b/src/passes/qptr.rs
@@ -1,8 +1,8 @@
 //! [`QPtr`](crate::TypeKind::QPtr) transforms.
 
+use crate::qptr;
 use crate::visit::{InnerVisit, Visitor};
 use crate::{AttrSet, Const, Context, Func, FxIndexSet, GlobalVar, Module, Type};
-use crate::{DataInstForm, qptr};
 
 pub fn lower_from_spv_ptrs(module: &mut Module, layout_config: &qptr::LayoutConfig) {
     let cx = &module.cx();
@@ -15,7 +15,6 @@ pub fn lower_from_spv_ptrs(module: &mut Module, layout_config: &qptr::LayoutConf
 
             seen_types: FxIndexSet::default(),
             seen_consts: FxIndexSet::default(),
-            seen_data_inst_forms: FxIndexSet::default(),
             seen_global_vars: FxIndexSet::default(),
             seen_funcs: FxIndexSet::default(),
         };
@@ -50,7 +49,6 @@ pub fn lift_to_spv_ptrs(module: &mut Module, layout_config: &qptr::LayoutConfig)
 
             seen_types: FxIndexSet::default(),
             seen_consts: FxIndexSet::default(),
-            seen_data_inst_forms: FxIndexSet::default(),
             seen_global_vars: FxIndexSet::default(),
             seen_funcs: FxIndexSet::default(),
         };
@@ -75,7 +73,6 @@ struct ReachableUseCollector<'a> {
     // FIXME(eddyb) build some automation to avoid ever repeating these.
     seen_types: FxIndexSet<Type>,
     seen_consts: FxIndexSet<Const>,
-    seen_data_inst_forms: FxIndexSet<DataInstForm>,
     seen_global_vars: FxIndexSet<GlobalVar>,
     seen_funcs: FxIndexSet<Func>,
 }
@@ -93,11 +90,6 @@ impl Visitor<'_> for ReachableUseCollector<'_> {
     fn visit_const_use(&mut self, ct: Const) {
         if self.seen_consts.insert(ct) {
             self.visit_const_def(&self.cx[ct]);
-        }
-    }
-    fn visit_data_inst_form_use(&mut self, data_inst_form: DataInstForm) {
-        if self.seen_data_inst_forms.insert(data_inst_form) {
-            self.visit_data_inst_form_def(&self.cx[data_inst_form]);
         }
     }
 

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -7,9 +7,9 @@ use super::{QPtrAttr, QPtrMemUsage, QPtrOp, QPtrUsage, shapes};
 use crate::func_at::FuncAt;
 use crate::visit::{InnerVisit, Visitor};
 use crate::{
-    AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstKind, Context, DataInst, DataInstForm,
-    DataInstKind, DeclDef, Diag, EntityList, ExportKey, Exportee, Func, FxIndexMap, GlobalVar,
-    Module, Node, NodeKind, OrdAssertEq, Type, TypeKind, Value,
+    AddrSpace, Attr, AttrSet, AttrSetDef, Const, ConstKind, Context, DataInst, DataInstKind,
+    DeclDef, Diag, EntityList, ExportKey, Exportee, Func, FxIndexMap, GlobalVar, Module, Node,
+    NodeKind, OrdAssertEq, Type, TypeKind, Value,
 };
 use itertools::Either;
 use rustc_hash::FxHashMap;
@@ -866,7 +866,6 @@ impl<'a> InferUsage<'a> {
             for func_at_inst in func_def_body.at(insts).into_iter().rev() {
                 let data_inst = func_at_inst.position;
                 let data_inst_def = func_at_inst.def();
-                let data_inst_form_def = &cx[data_inst_def.form];
                 let output_usage = data_inst_output_usages.remove(&data_inst).flatten();
 
                 let mut generate_usage = |this: &mut Self, ptr: Value, new_usage| {
@@ -904,7 +903,7 @@ impl<'a> InferUsage<'a> {
                         None => new_usage,
                     });
                 };
-                match &data_inst_form_def.kind {
+                match &data_inst_def.kind {
                     &DataInstKind::FuncCall(callee) => {
                         match self.infer_usage_in_func(module, callee) {
                             FuncInferUsageState::Complete(callee_results) => {
@@ -925,7 +924,7 @@ impl<'a> InferUsage<'a> {
                                 ));
                             }
                         };
-                        if data_inst_form_def.output_type.map_or(false, is_qptr) {
+                        if data_inst_def.output_type.map_or(false, is_qptr) {
                             if let Some(usage) = output_usage {
                                 usage_or_err_attrs_to_attach
                                     .push((Value::DataInstOutput(data_inst), usage));
@@ -1108,7 +1107,7 @@ impl<'a> InferUsage<'a> {
                     }
                     DataInstKind::QPtr(op @ (QPtrOp::Load | QPtrOp::Store)) => {
                         let (op_name, access_type) = match op {
-                            QPtrOp::Load => ("Load", data_inst_form_def.output_type.unwrap()),
+                            QPtrOp::Load => ("Load", data_inst_def.output_type.unwrap()),
                             QPtrOp::Store => {
                                 ("Store", func_at_inst.at(data_inst_def.inputs[1]).type_of(&cx))
                             }
@@ -1250,7 +1249,6 @@ impl Visitor<'_> for CollectAllDataInsts {
     fn visit_attr_set_use(&mut self, _: AttrSet) {}
     fn visit_type_use(&mut self, _: Type) {}
     fn visit_const_use(&mut self, _: Const) {}
-    fn visit_data_inst_form_use(&mut self, _: DataInstForm) {}
     fn visit_global_var_use(&mut self, _: GlobalVar) {}
     fn visit_func_use(&mut self, _: Func) {}
 

--- a/src/spv/mod.rs
+++ b/src/spv/mod.rs
@@ -58,8 +58,6 @@ pub struct Inst {
     // FIXME(eddyb) change the inline size of this to fit most instructions.
     // FIXME(eddyb) it might be worth investigating the performance implications
     // of interning "long immediates", compared to the flattened representation.
-    // NOTE(eddyb) interning these separately is likely unnecessary in many cases,
-    // now that `DataInstForm`s are interned, and `Const`s etc. were already.
     pub imms: SmallVec<[Imm; 2]>,
 }
 


### PR DESCRIPTION
Effectively undoes:
- https://github.com/EmbarkStudios/spirt/pull/28

Some quick unscientific testing reveals no significant perf impact (i.e. the difference is lost in the noise).

The motivation for undoing this interning is the prospect of combining `DataInstDef` into `NodeDef` (as mentioned in #7), and for unrelated pragmatic reasons, `NodeDef` can't have its outputs interned (though long-term maybe we could intern the `kind` field, if really necessary, assuming we first take "child regions" out of it).

The one thing I realized too late there's no pre-existing consensus for, is the `output_type`, which used to be between `kind` and `inputs` (matching `DataInstFormDef`, in fact), while `NodeDef`'s `outputs` is the last field.

The only argument to have outputs first is the `let (out0, out1) = foo(in0, in1);` style syntax (though pretty-printed SPIR-T omits the `let`), but I'm not sure that's worth flipping the order over.