### PR TITLE
Fix clippy and formatting post-Rust 1.87.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,8 @@ jobs:
           submodules: true
       - uses: actions-rs/toolchain@v1
         with:
-          # FIXME(eddyb) `style_edition = "2024"` in `rustfmt.toml` is what keeps
-          # this on `nightly`, should switch to `stable` when that stabilizes.
-          toolchain: nightly
-          # HACK(eddyb) use `nightly` by default without breaking the ability to
+          toolchain: stable
+          # HACK(eddyb) use `stable` by default without breaking the ability to
           # temporarily bypass it through `rust-toolchain.toml`.
           default: true
           override: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           override: true
       # NOTE(eddyb) this is the simplest way found so far to get `glslang`.
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.250.0
           vulkan-components: Glslang SPIRV-Tools

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "indexmap"

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() {
         std::env::current_dir().unwrap().join("khronos-spec/SPIRV-Headers/include/spirv/unified1");
     println!("cargo:rerun-if-changed={}", khr_spv_include_dir.display());
 
-    if !std::fs::metadata(&khr_spv_include_dir).map_or(false, |m| m.is_dir()) {
+    if !std::fs::metadata(&khr_spv_include_dir).is_ok_and(|m| m.is_dir()) {
         eprintln!(" error: {} is not a directory", khr_spv_include_dir.display());
         eprintln!("  help: git submodules are required to build from a git checkout");
         eprintln!("  help: run `git submodule update --init`");

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -84,17 +84,20 @@ impl ControlFlowGraph {
         func_def_body: &FuncDefBody,
     ) -> impl DoubleEndedIterator<Item = Region> {
         let mut post_order = SmallVec::<[_; 8]>::new();
-        self.traverse_whole_func(func_def_body, &mut TraversalState {
-            incoming_edge_counts: EntityOrientedDenseMap::new(),
+        self.traverse_whole_func(
+            func_def_body,
+            &mut TraversalState {
+                incoming_edge_counts: EntityOrientedDenseMap::new(),
 
-            pre_order_visit: |_| {},
-            post_order_visit: |region| post_order.push(region),
+                pre_order_visit: |_| {},
+                post_order_visit: |region| post_order.push(region),
 
-            // NOTE(eddyb) this doesn't impact semantics, but combined with
-            // the final reversal, it should keep targets in the original
-            // order in the cases when they didn't get deduplicated.
-            reverse_targets: true,
-        });
+                // NOTE(eddyb) this doesn't impact semantics, but combined with
+                // the final reversal, it should keep targets in the original
+                // order in the cases when they didn't get deduplicated.
+                reverse_targets: true,
+            },
+        );
         post_order.into_iter().rev()
     }
 }
@@ -906,10 +909,13 @@ impl DeferredEdgeBundleSet {
                     Err(new_deferred) => {
                         assert!(new_deferred.edge_bundle.target == target);
                         assert!(matches!(new_deferred.condition, LazyCond::True));
-                        (None, DeferredEdgeBundleSet::Always {
-                            target,
-                            edge_bundle: new_deferred.edge_bundle.with_target(()),
-                        })
+                        (
+                            None,
+                            DeferredEdgeBundleSet::Always {
+                                target,
+                                edge_bundle: new_deferred.edge_bundle.with_target(()),
+                            },
+                        )
                     }
                 }
             }
@@ -918,14 +924,17 @@ impl DeferredEdgeBundleSet {
                 for (i, (&target, deferred)) in target_to_deferred.iter_mut().enumerate() {
                     // HACK(eddyb) "take" `deferred` so it can be passed to
                     // `matches` (and put back if that returned `Err`).
-                    let taken_deferred = mem::replace(deferred, DeferredEdgeBundle {
-                        condition: LazyCond::False,
-                        edge_bundle: IncomingEdgeBundle {
-                            target: Default::default(),
-                            accumulated_count: Default::default(),
-                            target_inputs: Default::default(),
+                    let taken_deferred = mem::replace(
+                        deferred,
+                        DeferredEdgeBundle {
+                            condition: LazyCond::False,
+                            edge_bundle: IncomingEdgeBundle {
+                                target: Default::default(),
+                                accumulated_count: Default::default(),
+                                target_inputs: Default::default(),
+                            },
                         },
-                    });
+                    );
 
                     match matches(taken_deferred.with_target(target)) {
                         Ok(x) => {
@@ -1111,13 +1120,16 @@ impl<'a> Structurizer<'a> {
                 // in the general case (but special-cased because this is very
                 // close to being structurizable, just needs a bit of plumbing).
                 let mut control_inst_on_exit_from = EntityOrientedDenseMap::new();
-                control_inst_on_exit_from.insert(self.func_def_body.body, ControlInst {
-                    attrs: AttrSet::default(),
-                    kind: ControlInstKind::Unreachable,
-                    inputs: [].into_iter().collect(),
-                    targets: [].into_iter().collect(),
-                    target_inputs: FxIndexMap::default(),
-                });
+                control_inst_on_exit_from.insert(
+                    self.func_def_body.body,
+                    ControlInst {
+                        attrs: AttrSet::default(),
+                        kind: ControlInstKind::Unreachable,
+                        inputs: [].into_iter().collect(),
+                        targets: [].into_iter().collect(),
+                        target_inputs: FxIndexMap::default(),
+                    },
+                );
                 self.func_def_body.unstructured_cfg = Some(ControlFlowGraph {
                     control_inst_on_exit_from,
                     loop_merge_to_loop_header: Default::default(),
@@ -1133,13 +1145,15 @@ impl<'a> Structurizer<'a> {
 
             _ => {
                 // Repair all the regions that remain unclaimed, including the body.
-                let structurize_region_state = mem::take(&mut self.structurize_region_state)
-                    .into_iter()
-                    .chain([(self.func_def_body.body, StructurizeRegionState::Ready {
-                        accumulated_backedge_count: IncomingEdgeCount::default(),
+                let structurize_region_state =
+                    mem::take(&mut self.structurize_region_state).into_iter().chain([(
+                        self.func_def_body.body,
+                        StructurizeRegionState::Ready {
+                            accumulated_backedge_count: IncomingEdgeCount::default(),
 
-                        region_deferred_edges: func_body_deferred_edges,
-                    })]);
+                            region_deferred_edges: func_body_deferred_edges,
+                        },
+                    )]);
                 for (target, state) in structurize_region_state {
                     if let StructurizeRegionState::Ready { region_deferred_edges, .. } = state {
                         self.rebuild_cfg_from_unclaimed_region_deferred_edges(
@@ -1537,11 +1551,13 @@ impl<'a> Structurizer<'a> {
             .map(|backedge| backedge.accumulated_count)
             .unwrap_or_default();
 
-        let old_state =
-            self.structurize_region_state.insert(region, StructurizeRegionState::Ready {
+        let old_state = self.structurize_region_state.insert(
+            region,
+            StructurizeRegionState::Ready {
                 accumulated_backedge_count,
                 region_deferred_edges: deferred_edges,
-            });
+            },
+        );
         if !matches!(old_state, Some(StructurizeRegionState::InProgress)) {
             unreachable!(
                 "cfg::Structurizer::structurize_region: \

--- a/src/cfgssa.rs
+++ b/src/cfgssa.rs
@@ -458,6 +458,8 @@ mod data {
 
     // HACK(eddyb) most of the need for this arises from avoidance of
     // `unsafe` code (i.e. `MaybeUninit<V>` could suffice in most cases).
+    // FIXME(eddyb) figure out if keeping this around is useful at all.
+    #[allow(unused)]
     pub enum WrapNonDefaultValueInOption {}
     impl<V> ValueStorage<V> for WrapNonDefaultValueInOption {
         type Slot = Option<V>;

--- a/src/cfgssa.rs
+++ b/src/cfgssa.rs
@@ -228,10 +228,13 @@ impl<'a, BlockId: Copy + Eq + Hash, DefId: Copy + Eq + Hash, DefType: Copy>
             .map(|block_id| BlockIdx(self.def_map.blocks_by_id.get_index_of(&block_id).unwrap()));
 
         if self.blocks[target_block_idx].preds.insert(source_block_idx) {
-            self.add_uses_to(source_block_idx, AddUsesSource::PropagateBackwardsAcrossEdge {
-                target: target_block_idx,
-                only_dirty: false,
-            });
+            self.add_uses_to(
+                source_block_idx,
+                AddUsesSource::PropagateBackwardsAcrossEdge {
+                    target: target_block_idx,
+                    only_dirty: false,
+                },
+            );
         }
     }
 
@@ -240,10 +243,13 @@ impl<'a, BlockId: Copy + Eq + Hash, DefId: Copy + Eq + Hash, DefType: Copy>
             for i in 0..self.blocks[block_idx].preds.len() {
                 let pred_block_idx = self.blocks[block_idx].preds[i];
 
-                self.add_uses_to(pred_block_idx, AddUsesSource::PropagateBackwardsAcrossEdge {
-                    target: block_idx,
-                    only_dirty: true,
-                });
+                self.add_uses_to(
+                    pred_block_idx,
+                    AddUsesSource::PropagateBackwardsAcrossEdge {
+                        target: block_idx,
+                        only_dirty: true,
+                    },
+                );
             }
             self.blocks[block_idx].dirty_chunks.clear();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 // HACK(eddyb) using `(struct.Context.html)` to link `Context`, not `context::Context`.
 //! * [`Context`](struct.Context.html): handles interning ([`Type`]s, [`Const`]s, etc.) and allocating entity handles
 //! * [`Module`]: owns [`Func`]s and [`GlobalVar`]s (rooted by [`exports`](Module::exports))
-//! * [`FuncDefBody`]: owns [`Region`]s and [DataInst]s (rooted by [`body`](FuncDefBody::body))
+//! * [`FuncDefBody`]: owns [`Region`]s and [`DataInst`]s (rooted by [`body`](FuncDefBody::body))
 //!
 //! ##### Utilities and passes
 //! * [`print`](mod@print): pretty-printer with (styled and hyperlinked) HTML output
@@ -99,7 +99,6 @@
     clippy::map_err_ignore,
     clippy::map_flatten,
     clippy::map_unwrap_or,
-    clippy::match_on_vec_items,
     clippy::match_same_arms,
     clippy::match_wild_err_arm,
     clippy::match_wildcard_for_single_variants,

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -1824,9 +1824,10 @@ impl Print for spv::Dialect {
                             printer.pretty_spv_print_tokens_for_operand({
                                 let mut tokens = spv::print::operand_from_imms(cap_imms(cap));
                                 tokens.tokens.drain(..tokens.tokens.len() - 1);
-                                assert!(matches!(tokens.tokens[..], [
-                                    spv::print::Token::EnumerandName(_)
-                                ]));
+                                assert!(matches!(
+                                    tokens.tokens[..],
+                                    [spv::print::Token::EnumerandName(_)]
+                                ));
                                 tokens
                             })
                         });
@@ -1955,8 +1956,12 @@ impl Print for spv::ModuleDebugInfo {
                                                             printer.pretty_string_literal(
                                                                 &printer.cx[file],
                                                             ),
-                                                            pretty::join_space(":", [printer
-                                                                .pretty_string_literal(contents)]),
+                                                            pretty::join_space(
+                                                                ":",
+                                                                [printer.pretty_string_literal(
+                                                                    contents,
+                                                                )],
+                                                            ),
                                                         ])
                                                     })
                                                     .map(|entry| {
@@ -3050,10 +3055,13 @@ impl Print for FuncAt<'_, Node> {
                 let (inputs_header, body_suffix) = if !inputs.is_empty() {
                     let input_decls_and_uses =
                         inputs.iter().enumerate().map(|(input_idx, input)| {
-                            (input, Value::RegionInput {
-                                region: *body,
-                                input_idx: input_idx.try_into().unwrap(),
-                            })
+                            (
+                                input,
+                                Value::RegionInput {
+                                    region: *body,
+                                    input_idx: input_idx.try_into().unwrap(),
+                                },
+                            )
                         });
                     (
                         pretty::join_comma_sep(

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -2602,7 +2602,7 @@ impl Print for ConstDef {
                             Some(format!("{float:?}")).filter(|s| {
                                 s.parse::<FLOAT>()
                                     .map(float_to_bits)
-                                    .map_or(false, |roundtrip_bits| roundtrip_bits == bits)
+                                    .is_ok_and(|roundtrip_bits| roundtrip_bits == bits)
                             })
                         }
 

--- a/src/print/multiversion.rs
+++ b/src/print/multiversion.rs
@@ -196,7 +196,7 @@ impl Versions<pretty::FragmentPostLayout> {
                             .iter()
                             .zip(anchor_aligner.merged_columns())
                             .flat_map(|(&(_, repeat_count), column)| {
-                                iter::repeat(column).take(repeat_count)
+                                iter::repeat_n(column, repeat_count)
                             })
                             .peekable();
 
@@ -246,7 +246,7 @@ impl Versions<pretty::FragmentPostLayout> {
                                             }
                                             line
                                         }
-                                        other.map_or(false, |other| {
+                                        other.is_some_and(|other| {
                                             strip_indents(line) != strip_indents(other)
                                         })
                                     };
@@ -518,10 +518,7 @@ impl<'a> AnchorAligner<'a> {
             // Figure out which side has to wait, to align an upcoming anchor.
             let (old_at_anchor, new_at_anchor) =
                 next_anchor.map_or((false, false), |(anchor_old, anchor_new)| {
-                    (
-                        old_line_idx.map_or(false, |old| old == anchor_old),
-                        new_line_idx.map_or(false, |new| new == anchor_new),
-                    )
+                    (old_line_idx == Some(anchor_old), new_line_idx == Some(anchor_new))
                 });
             let old_line = if old_at_anchor && !new_at_anchor {
                 // Pausing "old", waiting for "new".

--- a/src/qptr/analyze.rs
+++ b/src/qptr/analyze.rs
@@ -323,7 +323,7 @@ impl UsageMerger<'_> {
                 // complex it may be (notably, this is needed for nested arrays).
                 if b.max_size
                     .and_then(|b_max_size| b_max_size.checked_add(b_offset_in_a_element))
-                    .map_or(false, |b_in_a_max_size| b_in_a_max_size <= a_stride.get())
+                    .is_some_and(|b_in_a_max_size| b_in_a_max_size <= a_stride.get())
                 {
                     // FIXME(eddyb) this in-place merging dance only needed due to `Rc`.
                     ({
@@ -402,7 +402,7 @@ impl UsageMerger<'_> {
                     ))
                     .rev()
                     .take_while(|(a_sub_offset, a_sub_usage)| {
-                        a_sub_usage.max_size.map_or(true, |a_sub_max_size| {
+                        a_sub_usage.max_size.is_none_or(|a_sub_max_size| {
                             a_sub_offset.checked_add(a_sub_max_size).unwrap() > b_offset_in_a
                         })
                     });
@@ -585,7 +585,7 @@ impl MemTypeLayout {
                 entries.iter().all(|(&sub_offset, sub_usage)| {
                     // FIXME(eddyb) maybe this overflow should be propagated up,
                     // as a sign that `usage` is malformed?
-                    usage_offset.checked_add(sub_offset).map_or(false, |combined_offset| {
+                    usage_offset.checked_add(sub_offset).is_some_and(|combined_offset| {
                         // NOTE(eddyb) the reason this is only applicable to
                         // offset `0` is that *in all other cases*, every
                         // individual `OffsetBase` requires its own type, to
@@ -924,7 +924,7 @@ impl<'a> InferUsage<'a> {
                                 ));
                             }
                         };
-                        if data_inst_def.output_type.map_or(false, is_qptr) {
+                        if data_inst_def.output_type.is_some_and(is_qptr) {
                             if let Some(usage) = output_usage {
                                 usage_or_err_attrs_to_attach
                                     .push((Value::DataInstOutput(data_inst), usage));

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -511,12 +511,15 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                     _ => return Err(LiftError(Diag::bug(["non-Buffer pointee".into()]))),
                 };
 
-                self.deferred_ptr_noops.insert(data_inst, DeferredPtrNoop {
-                    output_pointer: buf_ptr,
-                    output_pointer_addr_space: addr_space,
-                    output_pointee_layout: buf_data_layout,
-                    parent_block,
-                });
+                self.deferred_ptr_noops.insert(
+                    data_inst,
+                    DeferredPtrNoop {
+                        output_pointer: buf_ptr,
+                        output_pointer_addr_space: addr_space,
+                        output_pointee_layout: buf_data_layout,
+                        parent_block,
+                    },
+                );
 
                 DataInstDef {
                     kind: QPtrOp::BufferData.into(),
@@ -542,10 +545,10 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                                 last_field.mem_layout.fixed_base.size == 0
                                     && last_field.mem_layout.dyn_unit_stride
                                         == Some(dyn_unit_stride)
-                                    && matches!(last_field.components, Components::Elements {
-                                        fixed_len: None,
-                                        ..
-                                    })
+                                    && matches!(
+                                        last_field.components,
+                                        Components::Elements { fixed_len: None, .. }
+                                    )
                             }) =>
                     {
                         u32::try_from(offsets.len() - 1).unwrap()
@@ -640,12 +643,15 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                 }
 
                 if access_chain_inputs.len() == 1 {
-                    self.deferred_ptr_noops.insert(data_inst, DeferredPtrNoop {
-                        output_pointer: base_ptr,
-                        output_pointer_addr_space: addr_space,
-                        output_pointee_layout: TypeLayout::Concrete(layout),
-                        parent_block,
-                    });
+                    self.deferred_ptr_noops.insert(
+                        data_inst,
+                        DeferredPtrNoop {
+                            output_pointer: base_ptr,
+                            output_pointer_addr_space: addr_space,
+                            output_pointee_layout: TypeLayout::Concrete(layout),
+                            parent_block,
+                        },
+                    );
 
                     // FIXME(eddyb) avoid the repeated call to `type_of_val`,
                     // maybe don't even replace the `QPtrOp::Offset` instruction?

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -541,7 +541,7 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                 let field_idx = match &buf_data_layout.components {
                     Components::Fields { offsets, layouts }
                         if offsets.last() == Some(&fixed_base_size)
-                            && layouts.last().map_or(false, |last_field| {
+                            && layouts.last().is_some_and(|last_field| {
                                 last_field.mem_layout.fixed_base.size == 0
                                     && last_field.mem_layout.dyn_unit_stride
                                         == Some(dyn_unit_stride)

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -351,7 +351,7 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
             if let QPtrOp::DynOffset { stride, index_bounds } = &op {
                 let const_offset = const_idx_as_i32(dyn_idx.unwrap())
                     .filter(|const_idx| {
-                        index_bounds.as_ref().map_or(true, |bounds| bounds.contains(const_idx))
+                        index_bounds.as_ref().is_none_or(|bounds| bounds.contains(const_idx))
                     })
                     .and_then(|const_idx| i32::try_from(stride.get()).ok()?.checked_mul(const_idx));
                 if let Some(const_offset) = const_offset {

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -473,10 +473,10 @@ impl FuncAt<'_, Region> {
         let region = self.position;
         f(CfgCursor { point: CfgPoint::RegionEntry(region), parent })?;
         for func_at_node in self.at_children() {
-            func_at_node.rev_post_order_try_for_each_inner(f, &CfgCursor {
-                point: ControlParent::Region(region),
-                parent,
-            })?;
+            func_at_node.rev_post_order_try_for_each_inner(
+                f,
+                &CfgCursor { point: ControlParent::Region(region), parent },
+            )?;
         }
         f(CfgCursor { point: CfgPoint::RegionExit(region), parent })
     }
@@ -892,14 +892,17 @@ impl<'a> FuncLifting<'a> {
                     // they start being tracked.
                     if target_phis.is_empty() {
                         let extra_insts = mem::take(extra_insts);
-                        let new_terminator = mem::replace(new_terminator, Terminator {
-                            attrs: Default::default(),
-                            kind: Cow::Owned(cfg::ControlInstKind::Unreachable),
-                            inputs: Default::default(),
-                            targets: Default::default(),
-                            target_phi_values: Default::default(),
-                            merge: None,
-                        });
+                        let new_terminator = mem::replace(
+                            new_terminator,
+                            Terminator {
+                                attrs: Default::default(),
+                                kind: Cow::Owned(cfg::ControlInstKind::Unreachable),
+                                inputs: Default::default(),
+                                targets: Default::default(),
+                                target_phi_values: Default::default(),
+                                merge: None,
+                            },
+                        );
                         *target_use_count = 0;
 
                         let combined_block = &mut blocks[block_idx];

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -663,13 +663,16 @@ impl Module {
                     None => DeclDef::Present(GlobalVarDefBody { initializer }),
                 };
 
-                let global_var = module.global_vars.define(&cx, GlobalVarDecl {
-                    attrs: mem::take(&mut attrs),
-                    type_of_ptr_to: type_of_ptr_to_global_var,
-                    shape: None,
-                    addr_space: AddrSpace::SpvStorageClass(storage_class),
-                    def,
-                });
+                let global_var = module.global_vars.define(
+                    &cx,
+                    GlobalVarDecl {
+                        attrs: mem::take(&mut attrs),
+                        type_of_ptr_to: type_of_ptr_to_global_var,
+                        shape: None,
+                        addr_space: AddrSpace::SpvStorageClass(storage_class),
+                        def,
+                    },
+                );
                 let ptr_to_global_var = cx.intern(ConstDef {
                     attrs: AttrSet::default(),
                     ty: type_of_ptr_to_global_var,
@@ -752,14 +755,17 @@ impl Module {
                     }
                 };
 
-                let func = module.funcs.define(&cx, FuncDecl {
-                    attrs: mem::take(&mut attrs),
-                    ret_type: func_ret_type,
-                    params: func_type_param_types
-                        .map(|ty| FuncParam { attrs: AttrSet::default(), ty })
-                        .collect(),
-                    def,
-                });
+                let func = module.funcs.define(
+                    &cx,
+                    FuncDecl {
+                        attrs: mem::take(&mut attrs),
+                        ret_type: func_ret_type,
+                        params: func_type_param_types
+                            .map(|ty| FuncParam { attrs: AttrSet::default(), ty })
+                            .collect(),
+                        def,
+                    },
+                );
                 id_defs.insert(func_id, IdDef::Func(func));
 
                 current_func_body = Some(FuncBody { func_id, func, insts: vec![] });
@@ -912,11 +918,14 @@ impl Module {
                                 } else {
                                     func_def_body.regions.define(&cx, RegionDef::default())
                                 };
-                                block_details.insert(block, BlockDetails {
-                                    label_id: id,
-                                    phi_count: 0,
-                                    cfgssa_inter_block_uses: Default::default(),
-                                });
+                                block_details.insert(
+                                    block,
+                                    BlockDetails {
+                                        label_id: id,
+                                        phi_count: 0,
+                                        cfgssa_inter_block_uses: Default::default(),
+                                    },
+                                );
                                 LocalIdDef::BlockLabel(block)
                             } else if opcode == wk.OpPhi {
                                 let (&current_block, block_details) = match block_details.last_mut()
@@ -1398,13 +1407,10 @@ impl Module {
                         .as_mut()
                         .unwrap()
                         .control_inst_on_exit_from
-                        .insert(current_block.region, cfg::ControlInst {
-                            attrs,
-                            kind,
-                            inputs,
-                            targets,
-                            target_inputs,
-                        });
+                        .insert(
+                            current_block.region,
+                            cfg::ControlInst { attrs, kind, inputs, targets, target_inputs },
+                        );
                 } else if opcode == wk.OpPhi {
                     if !current_block_region_def.children.is_empty() {
                         return Err(invalid(

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -726,7 +726,7 @@ impl Module {
                         &print::Plan::for_root(
                             &cx,
                             &Diag::err([
-                                format!("in %{}, ", func_id).into(),
+                                format!("in %{func_id}, ").into(),
                                 "return type differs between `OpFunction` (".into(),
                                 func_ret_type.into(),
                                 ") and `OpTypeFunction` (".into(),
@@ -1200,7 +1200,7 @@ impl Module {
                 let func_def_body = func_def_body.as_deref_mut().unwrap();
 
                 let is_last_in_block = lookahead_raw_inst(1)
-                    .map_or(true, |next_raw_inst| next_raw_inst.without_ids.opcode == wk.OpLabel);
+                    .is_none_or(|next_raw_inst| next_raw_inst.without_ids.opcode == wk.OpLabel);
 
                 if opcode == wk.OpLabel {
                     if is_last_in_block {
@@ -1424,9 +1424,7 @@ impl Module {
                         .push(RegionInputDecl { attrs, ty: result_type.unwrap() });
                 } else if [wk.OpSelectionMerge, wk.OpLoopMerge].contains(&opcode) {
                     let is_second_to_last_in_block = lookahead_raw_inst(2)
-                        .map_or(true, |next_raw_inst| {
-                            next_raw_inst.without_ids.opcode == wk.OpLabel
-                        });
+                        .is_none_or(|next_raw_inst| next_raw_inst.without_ids.opcode == wk.OpLabel);
 
                     if !is_second_to_last_in_block {
                         return Err(invalid(
@@ -1612,7 +1610,7 @@ impl Module {
                             &print::Plan::for_root(
                                 &cx,
                                 &Diag::err([
-                                    format!("in %{}, ", func_id).into(),
+                                    format!("in %{func_id}, ").into(),
                                     format!("param #{i}'s type differs between `OpTypeFunction` (")
                                         .into(),
                                     func_decl_param.ty.into(),

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -846,10 +846,13 @@ impl Spec {
                     bases[0] = "LiteralContextDependentNumber";
                 }
 
-                (o.kind, [
-                    operand_kinds.lookup(bases[0]).unwrap(),
-                    operand_kinds.lookup(bases[1]).unwrap(),
-                ])
+                (
+                    o.kind,
+                    [
+                        operand_kinds.lookup(bases[0]).unwrap(),
+                        operand_kinds.lookup(bases[1]).unwrap(),
+                    ],
+                )
             })
             .collect();
 

--- a/src/spv/write.rs
+++ b/src/spv/write.rs
@@ -211,9 +211,9 @@ impl ModuleEmitter {
         let expected_final_pos = self.words.len() + total_word_count;
 
         let opcode = u32::from(inst.opcode.as_u16())
-            | u32::from(u16::try_from(total_word_count).ok().ok_or_else(|| {
+            | (u32::from(u16::try_from(total_word_count).ok().ok_or_else(|| {
                 invalid("word count of SPIR-V instruction doesn't fit in 16 bits")
-            })?) << 16;
+            })?) << 16);
         self.words.extend(
             iter::once(opcode)
                 .chain(inst.result_type_id.map(|id| id.get()))


### PR DESCRIPTION
Formatting-wise we've seen something similar in Rust-GPU, and it has to do with the adoption of `style_edition = "2024"` in `rustfmt.toml` before that had some "last-minute" changes.

Hopefully CI passes with the change from nightly to stable (nightly was used due to rustfmt previously).