### PR TITLE
print: name and reuse inlined call site debuginfo "scopes".

### DIFF
--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -68,6 +68,14 @@ impl<'a> Iterator for FuncAt<'a, EntityListIter<Node>> {
     }
 }
 
+impl DoubleEndedIterator for FuncAt<'_, EntityListIter<Node>> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let (prev, rest) = self.position.split_last(self.nodes)?;
+        self.position = rest;
+        Some(self.at(prev))
+    }
+}
+
 impl<'a> FuncAt<'a, Node> {
     pub fn def(self) -> &'a NodeDef {
         &self.nodes[self.position]


### PR DESCRIPTION
This addresses the visual (and functional) bloat caused by accurate (wrt inlining) debuginfo from Rust-GPU,
which on the motivating example, results in these changes:

<sub>(middle column obtained by making `DbgScope::maybe_print_name_as_ref_or_def` always return `None`, which should *not* be considered likely output after this PR, it's only kept around as a fallback, e.g. if intra-function debuginfo ends up used in `Const` attributes etc.)</sub>

||Before this PR|New style w/o reuse|After this PR|
|-:|-:|-:|:-|
|<sub><sup>`.spirt`<br>line count</sup></sub>|190498|190498|46365|
|<sub><sup>`.spirt.html`<br>file size</sup></sub>|96 MiB|95.2 MiB|33.5 MiB|
|<sub><sup>Worst-case<br>comparison</sup></sub>|<img src="https://github.com/user-attachments/assets/bf12754c-038e-4832-82a8-82f0b0edaa26" width="256">|<img src="https://github.com/user-attachments/assets/0ace90bc-0b55-4bc8-9123-63f9fe68e340" width="256">|<img src="https://github.com/user-attachments/assets/42902024-0c74-48e9-8349-0803bf475bbb" width="128">|

(**EDIT**: I've sadly had to force widths via explicit `<img>` tags because GitHub started applying `overflow-wrap: anywhere` *to the entire markdown render output*, which means individual letters in the text cells are competing against whole `<img>`s, during table layout, and the letters end up inevitably all in one vertical line)

---

Initially I was hoping for some kind of "stateful" comment system, and/or showing "debug scopes" using braces within the debuginfo comments, but the <code>// d<sub>123</sub> = ...</code> notation added in this PR was an algorithmic nightmare as-is. <sub>(mainly because of multi-version support, where uses of debuginfo can easily disappear/move as nodes get simplified/wholly removed/etc. in various passes, making it hard so share common placements for such debuginfo "definitions")</sub>

Also, it's been aesthetically tricky to handle the transition from "location of (inlined) call site" to "location inside (inlined) callee", and this PR ended up flipping the order, from inside-out to outside-in. <sub>(you might be able to tell between the first and second column, it used to look like a backtrace that keeps "zooming out", from leaf function to entry-point, whereas now it "zooms in", keeping the leaf-most location closest to whatever follows the debuginfo comments)</sub>

That 33.5 MiB `.spirt.html` after this PR still makes browsers a bit unhappy. <sub>(I was going to share more comparisons but even that single one took minutes per screenshot just to scroll with the Firefox screenshot tool!)</sub>
<sub>(specific HTML size/complexity issues might be fixable, but it's hard to tell what browsers are struggling with most, without actually testing a tentative change)</sub>

*However*, it's a far cry from what it used to be, and any visual and UX improvements are welcome.
<sub>(let alone the 216 MiB file I started from, before fixing the `format_args!` "decompiler" on my Rust-GPU branch, as the output was full of `core::fmt` internals, esp. kept alive by function pointers/vtables)</sub>

---

Not sure how to handle reviews, but I would gladly walk someone through all of this mess if anyone cares.
(Thought, just like the other recent pretty-printer PRs, this is *purely* about aesthetics/ergonomics, so anything being "wrong" or "imprecise" shouldn't affect the correctness of actual SPIR-T passes etc.)