### PR TITLE
rustfmt: manually split up string literals crossing the maximum line width.

### DIFF
--- a/src/qptr/layout.rs
+++ b/src/qptr/layout.rs
@@ -475,7 +475,8 @@ impl<'a> LayoutCache<'a> {
                             }
                             Ordering::Greater => {
                                 return Err(LayoutError(Diag::bug([
-                                    "structs with explicit offsets must provide them for all fields"
+                                    "structs with explicit offsets \
+                                     must provide them for all fields"
                                         .into(),
                                 ])));
                             }

--- a/src/qptr/lift.rs
+++ b/src/qptr/lift.rs
@@ -603,9 +603,11 @@ impl LiftToSpvPtrInstsInFunc<'_> {
                                 // FIXME(eddyb) this could include the chosen indices,
                                 // and maybe the current type and/or layout.
                                 return Err(LiftError(Diag::bug([format!(
-                                    "offset {offset} not found in type layout, after {} access chain indices",
+                                    "offset {offset} not found in type layout, \
+                                     after {} access chain indices",
                                     access_chain_inputs.len() - 1
-                                ).into()])));
+                                )
+                                .into()])));
                             }
                             (Some(idx), Some(_)) => {
                                 // FIXME(eddyb) !!! this can also be illegal overlap

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -1675,20 +1675,14 @@ impl Module {
                     Ok((ExportKey::LinkName(name), exportee))
                 }
 
-                Export::EntryPoint {
-                    func_id,
-                    imms,
-                    interface_ids,
-                } => {
+                Export::EntryPoint { func_id, imms, interface_ids } => {
                     let func = match id_defs.get(&func_id) {
                         Some(&IdDef::Func(func)) => Ok(func),
                         Some(id_def) => Err(id_def.descr(&cx)),
                         None => Err(format!("unknown ID %{func_id}")),
                     }
                     .map_err(|descr| {
-                        invalid(&format!(
-                            "unsupported use of {descr} as the `OpEntryPoint` target"
-                        ))
+                        invalid(&format!("unsupported use of {descr} as the `OpEntryPoint` target"))
                     })?;
                     let interface_global_vars = interface_ids
                         .into_iter()
@@ -1703,16 +1697,14 @@ impl Module {
                         .map(|result| {
                             result.map_err(|descr| {
                                 invalid(&format!(
-                                    "unsupported use of {descr} as an `OpEntryPoint` interface variable"
+                                    "unsupported use of {descr} as an \
+                                     `OpEntryPoint` interface variable"
                                 ))
                             })
                         })
                         .collect::<Result<_, _>>()?;
                     Ok((
-                        ExportKey::SpvEntryPoint {
-                            imms,
-                            interface_global_vars,
-                        },
+                        ExportKey::SpvEntryPoint { imms, interface_global_vars },
                         Exportee::Func(func),
                     ))
                 }

--- a/src/spv/spec.rs
+++ b/src/spv/spec.rs
@@ -683,10 +683,7 @@ impl Spec {
                             .unwrap();
                     }
 
-                    Enumerant {
-                        req_params,
-                        rest_params,
-                    }
+                    Enumerant { req_params, rest_params }
                 };
 
                 let def = match o.category {
@@ -732,7 +729,8 @@ impl Spec {
                                     // Only allow aliases that do not meaningfully differ.
                                     assert!(
                                         prev_enumerant == new_enumerant,
-                                        "{} bits {} and {} share a bit index but differ in definition",
+                                        "{} bits {} and {} share a bit index \
+                                         but differ in definition",
                                         o.kind,
                                         prev_name,
                                         new_name,
@@ -757,10 +755,7 @@ impl Spec {
                             storage: bits,
                         };
 
-                        OperandKindDef::BitEnum {
-                            empty_name: empty_name.unwrap_or("None"),
-                            bits,
-                        }
+                        OperandKindDef::BitEnum { empty_name: empty_name.unwrap_or("None"), bits }
                     }
                     raw::OperandKindCategory::ValueEnum => {
                         assert!(o.bases.is_none());
@@ -768,10 +763,7 @@ impl Spec {
                         let enumerants = o.enumerants.as_ref().unwrap();
                         let variants = indexed::KhrSegmentedVec::from_in_order_iter(
                             enumerants.iter().map(|e| {
-                                (
-                                    e.value.try_into().unwrap(),
-                                    (e.enumerant, enumerant_from_raw(e)),
-                                )
+                                (e.value.try_into().unwrap(), (e.enumerant, enumerant_from_raw(e)))
                             }),
                             // `merge_duplicates` closure:
                             |(prev_name, prev_enumerant), (new_name, new_enumerant)| {
@@ -784,10 +776,7 @@ impl Spec {
                                     new_name,
                                 );
 
-                                (
-                                    preferred_name_between_dups(prev_name, new_name),
-                                    new_enumerant,
-                                )
+                                (preferred_name_between_dups(prev_name, new_name), new_enumerant)
                             },
                         );
 


### PR DESCRIPTION
There's an unfortunate `rustfmt` bug/limitation, where string literals that cross the max width breaks reformatting in everything it's nested in.

The resulting files were tested for reformatting ability by (un)indenting the entire file (e.g. `Ctrl+A Tab Ctrl+S` in VSCode), and inspecting the resulting diff - complete success leads to only whitespace changes in lines that are string `\` continuations (because `rustfmt` doesn't touch those).

In fact, to ensure all instances are caught, I ended up doing this instead:
```sh
sed -E -i 's/^./ \0/' src/**.rs && cargo fmt --all && git diff
```
(sadly, macros also don't get reformatted, so this is a bit annoying to skim, but still useful)

---

You can see in the diff that there was some positive overall impact by looking for formatting changes that are *not* directly around the changed strings, but rather in nearby (sibling-ish) AST nodes.