### PR TITLE
Introduce a `Var` entity to give an identity to region inputs and node outputs.

### DIFF
--- a/src/cf/unstructured.rs
+++ b/src/cf/unstructured.rs
@@ -30,7 +30,7 @@ pub struct ControlInst {
     pub targets: SmallVec<[Region; 4]>,
 
     /// `target_inputs[region][input_idx]` is the [`Value`] that
-    /// `Value::RegionInput { region, input_idx }` will get on entry,
+    /// `VarKind::RegionInput { region, input_idx }` will get on entry,
     /// where `region` must be appear at least once in `targets` - this is a
     /// separate map instead of being part of `targets` because it reflects the
     /// limitations of φ ("phi") nodes, which (unlike "basic block arguments")

--- a/src/context.rs
+++ b/src/context.rs
@@ -957,4 +957,5 @@ entities! {
     Func => chunk_size(0x1_0000) crate::FuncDecl,
     Region => chunk_size(0x1000) crate::RegionDef,
     Node => chunk_size(0x1000) EntityListNode<Node, crate::NodeDef>,
+    Var => chunk_size(0x1000) crate::VarDecl,
 }

--- a/src/func_at.rs
+++ b/src/func_at.rs
@@ -13,7 +13,7 @@
 
 use crate::{
     Context, EntityDefs, EntityList, EntityListIter, FuncDefBody, Node, NodeDef, Region, RegionDef,
-    Type, Value,
+    Type, Value, Var, VarKind,
 };
 
 /// Immutable traversal (i.e. visiting) helper for intra-function entities.
@@ -81,10 +81,19 @@ impl FuncAt<'_, Value> {
     pub fn type_of(self, cx: &Context) -> Type {
         match self.position {
             Value::Const(ct) => cx[ct].ty,
-            Value::RegionInput { region, input_idx } => {
+            Value::Var(var) => self.at(var).type_of(),
+        }
+    }
+}
+
+impl FuncAt<'_, Var> {
+    /// Return the [`Type`] of this [`Var`].
+    pub fn type_of(self) -> Type {
+        match self.position {
+            VarKind::RegionInput { region, input_idx } => {
                 self.at(region).def().inputs[input_idx as usize].ty
             }
-            Value::NodeOutput { node, output_idx } => {
+            VarKind::NodeOutput { node, output_idx } => {
                 self.at(node).def().outputs[output_idx as usize].ty
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -706,7 +706,7 @@ pub struct FuncDefBody {
     /// The [`Region`] representing the whole body of the function.
     ///
     /// Function parameters are provided via `body.inputs`, i.e. they can be
-    /// only accessed with `Value::RegionInputs { region: body, idx }`.
+    /// only accessed with `VarKind::RegionInput { region: body, idx }`.
     ///
     /// When `unstructured_cfg` is `None`, this includes the structured return
     /// of the function, with `body.outputs` as the returned values.
@@ -814,7 +814,7 @@ pub use context::Region;
 #[derive(Clone, Default)]
 pub struct RegionDef {
     /// Inputs to this [`Region`]:
-    /// * accessed using [`Value::RegionInput`]
+    /// * accessed using [`VarKind::RegionInput`]
     /// * values provided by the parent:
     ///   * when this is the function body: the function's parameters
     pub inputs: SmallVec<[RegionInputDecl; 2]>,
@@ -824,11 +824,11 @@ pub struct RegionDef {
     /// Output values from this [`Region`], provided to the parent:
     /// * when this is the function body: these are the structured return values
     /// * when this is a `Select` case: these are the values for the parent
-    ///   [`Node`]'s outputs (accessed using [`Value::NodeOutput`])
+    ///   [`Node`]'s outputs (accessed using [`VarKind::NodeOutput`])
     /// * when this is a `Loop` body: these are the values to be used for the
     ///   next loop iteration's body `inputs`
-    ///   * **not** accessible through [`Value::NodeOutput`] on the `Loop`,
-    ///     as it's both confusing regarding [`Value::RegionInput`], and
+    ///   * **not** accessible through [`VarKind::NodeOutput`] on the `Loop`,
+    ///     as it's both confusing regarding [`VarKind::RegionInput`], and
     ///     also there's nothing stopping body-defined values from directly being
     ///     used outside the loop (once that changes, this aspect can be flipped)
     pub outputs: SmallVec<[Value; 2]>,
@@ -863,7 +863,7 @@ pub struct NodeDef {
     pub child_regions: SmallVec<[Region; 2]>,
 
     /// Outputs from this [`Node`]:
-    /// * accessed using [`Value::NodeOutput`]
+    /// * accessed using [`VarKind::NodeOutput`]
     /// * values provided by `region.outputs`, where `region` is the executed
     ///   child [`Region`]:
     ///   * when this is a `Select`: the case that was chosen
@@ -942,15 +942,22 @@ pub type DataInstKind = NodeKind;
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Value {
     Const(Const),
+    Var(Var),
+}
 
+type Var = VarKind;
+
+// FIXME(eddyb) document the fact that "variable" is used here in a sense
+// more like e.g. math/lambda calculus/SSA/Rust immutable variables,
+// and *not* some sort of "mutable slot" (like e.g. wasm local variables),
+// also mention `GlobalVar`/`mem::MemOp::FuncLocalVar`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum VarKind {
     /// One of the inputs to a [`Region`]:
     /// * declared by `region.inputs[input_idx]`
     /// * value provided by the parent of the `region`:
     ///   * when `region` is the function body: `input_idx`th function parameter
-    RegionInput {
-        region: Region,
-        input_idx: u32,
-    },
+    RegionInput { region: Region, input_idx: u32 },
 
     /// One of the outputs produced by a [`Node`]:
     /// * declared by `node.outputs[output_idx]`
@@ -958,8 +965,5 @@ pub enum Value {
     ///   executed child [`Region`] (of `node`):
     ///   * when `node` is a `Select`: the case that was chosen
     // TODO(eddyb) include former `DataInst`s in above docs.
-    NodeOutput {
-        node: Node,
-        output_idx: u32,
-    },
+    NodeOutput { node: Node, output_idx: u32 },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,8 +548,8 @@ pub enum TypeKind {
     /// (e.g. "points to variable `x`" or "accessed at offset `y`") can be found
     /// attached as `Attr`s on those `Value`s (see [`Attr::QPtr`]).
     //
-    // FIXME(eddyb) a "refinement system" that's orthogonal from types, and kept
-    // separately in e.g. `RegionInputDecl`, might be a better approach?
+    // FIXME(eddyb) a "refinement system" that's orthogonal from types,
+    // and kept separately in `VarDecl`, might be a better approach?
     QPtr,
 
     SpvInst {
@@ -702,6 +702,7 @@ pub struct FuncParam {
 pub struct FuncDefBody {
     pub regions: EntityDefs<Region>,
     pub nodes: EntityDefs<Node>,
+    pub vars: EntityDefs<Var>,
 
     /// The [`Region`] representing the whole body of the function.
     ///
@@ -817,7 +818,7 @@ pub struct RegionDef {
     /// * accessed using [`VarKind::RegionInput`]
     /// * values provided by the parent:
     ///   * when this is the function body: the function's parameters
-    pub inputs: SmallVec<[RegionInputDecl; 2]>,
+    pub inputs: SmallVec<[Var; 2]>,
 
     pub children: EntityList<Node>,
 
@@ -832,13 +833,6 @@ pub struct RegionDef {
     ///     also there's nothing stopping body-defined values from directly being
     ///     used outside the loop (once that changes, this aspect can be flipped)
     pub outputs: SmallVec<[Value; 2]>,
-}
-
-#[derive(Copy, Clone)]
-pub struct RegionInputDecl {
-    pub attrs: AttrSet,
-
-    pub ty: Type,
 }
 
 /// Entity handle for a [`NodeDef`](crate::NodeDef)
@@ -868,14 +862,7 @@ pub struct NodeDef {
     ///   child [`Region`]:
     ///   * when this is a `Select`: the case that was chosen
     // TODO(eddyb) include former `DataInst`s in above docs.
-    pub outputs: SmallVec<[NodeOutputDecl; 2]>,
-}
-
-#[derive(Copy, Clone)]
-pub struct NodeOutputDecl {
-    pub attrs: AttrSet,
-
-    pub ty: Type,
+    pub outputs: SmallVec<[Var; 2]>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From)]
@@ -939,19 +926,42 @@ pub type DataInst = Node;
 pub type DataInstDef = NodeDef;
 pub type DataInstKind = NodeKind;
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Value {
-    Const(Const),
-    Var(Var),
-}
-
-type Var = VarKind;
-
+// FIXME(eddyb) should this be above region/node?
 // FIXME(eddyb) document the fact that "variable" is used here in a sense
 // more like e.g. math/lambda calculus/SSA/Rust immutable variables,
 // and *not* some sort of "mutable slot" (like e.g. wasm local variables),
 // also mention `GlobalVar`/`mem::MemOp::FuncLocalVar`.
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub use context::Var;
+
+/// Declaration for a [`Var`]: a [`Region`] input or [`Node`] output.
+#[derive(Clone)]
+pub struct VarDecl {
+    pub attrs: AttrSet,
+
+    pub ty: Type,
+
+    // FIXME(eddyb) add a `context::PackedEither` using the sign of s/u32/i32/
+    // interned/entity, and use it to be more compact than `Either<Region, Node>`.
+    pub def_parent: itertools::Either<Region, Node>,
+    pub def_idx: u32,
+}
+
+impl VarDecl {
+    // FIXME(eddyb) `VarKind` maybe should've been `VarDef`, but the `Def` suffix
+    // can get confusing, and `VarKind` was picked early in the refactor.
+    // FIXME(eddyb) document that the indices returned are only valid while the
+    // `Var`s (`RegionDef` `inputs` or `NodeDef` `outputs`) remain unchanged.
+    pub fn kind(&self) -> VarKind {
+        self.def_parent.either(
+            |region| VarKind::RegionInput { region, input_idx: self.def_idx },
+            |node| VarKind::NodeOutput { node, output_idx: self.def_idx },
+        )
+    }
+}
+
+// FIXME(eddyb) consider using `usize` (still packed as `u32`) for indices.
+// FIXME(eddyb) document that the indices contained are only valid while the
+// `Var`s (`RegionDef` `inputs` or `NodeDef` `outputs`) remain unchanged.
 pub enum VarKind {
     /// One of the inputs to a [`Region`]:
     /// * declared by `region.inputs[input_idx]`
@@ -966,4 +976,12 @@ pub enum VarKind {
     ///   * when `node` is a `Select`: the case that was chosen
     // TODO(eddyb) include former `DataInst`s in above docs.
     NodeOutput { node: Node, output_idx: u32 },
+}
+
+// FIXME(eddyb) add a `context::PackedEither` using the sign of s/u32/i32/
+// interned/entity, and use it to be more compact than `Either<Const, Var>`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Value {
+    Const(Const),
+    Var(Var),
 }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -248,16 +248,7 @@ enum Use {
 
     RegionLabel(Region),
 
-    // FIXME(eddyb) these are `Value`'s variants except `Const`, maybe `Use`
-    // should just use `Value` and assert it's never `Const`?
-    RegionInput {
-        region: Region,
-        input_idx: u32,
-    },
-    NodeOutput {
-        node: Node,
-        output_idx: u32,
-    },
+    Var(VarKind),
 
     // NOTE(eddyb) these overlap somewhat with other cases, but they're always
     // generated, even when there is no "use", for `multiversion` alignment.
@@ -269,12 +260,7 @@ impl From<Value> for Use {
     fn from(value: Value) -> Self {
         match value {
             Value::Const(ct) => Use::CxInterned(CxInterned::Const(ct)),
-            Value::Var(VarKind::RegionInput { region, input_idx }) => {
-                Use::RegionInput { region, input_idx }
-            }
-            Value::Var(VarKind::NodeOutput { node, output_idx }) => {
-                Use::NodeOutput { node, output_idx }
-            }
+            Value::Var(v) => Use::Var(v),
         }
     }
 }
@@ -292,9 +278,7 @@ impl Use {
 
             Self::DbgScope { .. } => ("", "d"),
             Self::RegionLabel(_) => ("label", "L"),
-
-            Self::RegionInput { .. } | Self::NodeOutput { .. } => ("", "v"),
-
+            Self::Var(_) => ("", "v"),
             Self::AlignmentAnchorForRegion(_) | Self::AlignmentAnchorForNode(_) => {
                 ("", Self::ANCHOR_ALIGNMENT_NAME_PREFIX)
             }
@@ -1062,9 +1046,7 @@ impl<'a> Printer<'a> {
             .iter()
             .map(|(&use_kind, &use_count)| {
                 // HACK(eddyb) these are assigned later.
-                if let Use::RegionLabel(_) | Use::RegionInput { .. } | Use::NodeOutput { .. } =
-                    use_kind
-                {
+                if let Use::RegionLabel(_) | Use::Var(_) = use_kind {
                     return (use_kind, UseStyle::Inline);
                 }
 
@@ -1096,8 +1078,7 @@ impl<'a> Printer<'a> {
                     }
                     Use::DbgScope { .. }
                     | Use::RegionLabel(_)
-                    | Use::RegionInput { .. }
-                    | Use::NodeOutput { .. }
+                    | Use::Var(_)
                     | Use::AlignmentAnchorForRegion(_)
                     | Use::AlignmentAnchorForNode(_) => unreachable!(),
                 }
@@ -1169,8 +1150,7 @@ impl<'a> Printer<'a> {
 
                     Use::DbgScope { .. }
                     | Use::RegionLabel(_)
-                    | Use::RegionInput { .. }
-                    | Use::NodeOutput { .. }
+                    | Use::Var(_)
                     | Use::AlignmentAnchorForRegion(_)
                     | Use::AlignmentAnchorForNode(_) => {
                         unreachable!()
@@ -1193,8 +1173,7 @@ impl<'a> Printer<'a> {
                         )
                         | Use::DbgScope { .. }
                         | Use::RegionLabel(_)
-                        | Use::RegionInput { .. }
-                        | Use::NodeOutput { .. }
+                        | Use::Var(_)
                         | Use::AlignmentAnchorForRegion(_)
                         | Use::AlignmentAnchorForNode(_) => {
                             unreachable!()
@@ -1477,7 +1456,10 @@ impl<'a> Printer<'a> {
 
                         for (i, input_decl) in inputs.iter().enumerate() {
                             define(
-                                Use::RegionInput { region, input_idx: i.try_into().unwrap() },
+                                Use::Var(VarKind::RegionInput {
+                                    region,
+                                    input_idx: i.try_into().unwrap(),
+                                }),
                                 Some(input_decl.attrs),
                             );
                         }
@@ -1497,7 +1479,10 @@ impl<'a> Printer<'a> {
 
                         for (i, output_decl) in outputs.iter().enumerate() {
                             define(
-                                Use::NodeOutput { node, output_idx: i.try_into().unwrap() },
+                                Use::Var(VarKind::NodeOutput {
+                                    node,
+                                    output_idx: i.try_into().unwrap(),
+                                }),
                                 Some(output_decl.attrs),
                             );
                         }
@@ -1523,9 +1508,7 @@ impl<'a> Printer<'a> {
                         (&mut region_label_counter, use_styles.get_mut(&use_kind))
                     }
 
-                    Use::RegionInput { .. } | Use::NodeOutput { .. } => {
-                        (&mut value_counter, use_styles.get_mut(&use_kind))
-                    }
+                    Use::Var(_) => (&mut value_counter, use_styles.get_mut(&use_kind)),
 
                     Use::AlignmentAnchorForRegion(_) | Use::AlignmentAnchorForNode(_) => (
                         &mut alignment_anchor_counter,
@@ -2147,10 +2130,7 @@ impl Use {
                     ))
                     .into(),
 
-                Self::DbgScope { .. }
-                | Self::RegionLabel(_)
-                | Self::RegionInput { .. }
-                | Self::NodeOutput { .. } => "_".into(),
+                Self::DbgScope { .. } | Self::RegionLabel(_) | Self::Var(_) => "_".into(),
 
                 Self::AlignmentAnchorForRegion(_) | Self::AlignmentAnchorForNode(_) => {
                     unreachable!()
@@ -3901,8 +3881,8 @@ impl FuncAt<'_, DataInst> {
             None
         };
 
-        let mut output_use_to_print_as_lhs =
-            output_type.map(|_| Use::NodeOutput { node: self.position, output_idx: 0 });
+        let mut output_use_to_print_as_lhs = output_type
+            .map(|_| Use::Var(VarKind::NodeOutput { node: self.position, output_idx: 0 }));
 
         let mut output_type_to_print = output_type;
 

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     EntityOrientedDenseMap, ExportKey, Exportee, Func, FuncDecl, FuncDefBody, FuncParam,
     FxIndexMap, FxIndexSet, GlobalVar, GlobalVarDecl, GlobalVarDefBody, Import, InternedStr,
     Module, ModuleDebugInfo, ModuleDialect, Node, NodeDef, NodeKind, NodeOutputDecl, OrdAssertEq,
-    Region, RegionDef, RegionInputDecl, Type, TypeDef, TypeKind, TypeOrConst, Value, spv,
+    Region, RegionDef, RegionInputDecl, Type, TypeDef, TypeKind, TypeOrConst, Value, VarKind, spv,
 };
 use arrayvec::ArrayVec;
 use itertools::Either;
@@ -269,8 +269,12 @@ impl From<Value> for Use {
     fn from(value: Value) -> Self {
         match value {
             Value::Const(ct) => Use::CxInterned(CxInterned::Const(ct)),
-            Value::RegionInput { region, input_idx } => Use::RegionInput { region, input_idx },
-            Value::NodeOutput { node, output_idx } => Use::NodeOutput { node, output_idx },
+            Value::Var(VarKind::RegionInput { region, input_idx }) => {
+                Use::RegionInput { region, input_idx }
+            }
+            Value::Var(VarKind::NodeOutput { node, output_idx }) => {
+                Use::NodeOutput { node, output_idx }
+            }
         }
     }
 }
@@ -644,7 +648,7 @@ impl<'a> Visitor<'a> for Plan<'a> {
     fn visit_value_use(&mut self, v: &'a Value) {
         match *v {
             Value::Const(_) => {}
-            _ => *self.use_counts.entry(Use::from(*v)).or_default() += 1,
+            Value::Var(_) => *self.use_counts.entry(Use::from(*v)).or_default() += 1,
         }
         v.inner_visit_with(self);
     }
@@ -3530,10 +3534,10 @@ impl Print for FuncDecl {
                 params.iter().enumerate().map(|(i, param)| {
                     let param_name = match def {
                         DeclDef::Imported(_) => "_".into(),
-                        DeclDef::Present(def) => Value::RegionInput {
+                        DeclDef::Present(def) => Value::Var(VarKind::RegionInput {
                             region: def.body,
                             input_idx: i.try_into().unwrap(),
-                        }
+                        })
                         .print_as_def(printer),
                     };
                     param.print(printer).insert_name_before_def(param_name)
@@ -3566,10 +3570,10 @@ impl Print for FuncDecl {
                                         "(",
                                         inputs.iter().enumerate().map(|(input_idx, input)| {
                                             input.print(printer).insert_name_before_def(
-                                                Value::RegionInput {
+                                                Value::Var(VarKind::RegionInput {
                                                     region,
                                                     input_idx: input_idx.try_into().unwrap(),
-                                                }
+                                                })
                                                 .print_as_def(printer),
                                             )
                                         }),
@@ -3715,8 +3719,11 @@ impl Print for FuncAt<'_, Node> {
         let outputs_header = if !outputs.is_empty() {
             let mut outputs = outputs.iter().enumerate().map(|(output_idx, output)| {
                 output.print(printer).insert_name_before_def(
-                    Value::NodeOutput { node, output_idx: output_idx.try_into().unwrap() }
-                        .print_as_def(printer),
+                    Value::Var(VarKind::NodeOutput {
+                        node,
+                        output_idx: output_idx.try_into().unwrap(),
+                    })
+                    .print_as_def(printer),
                 )
             });
             let outputs_lhs = if outputs.len() == 1 {
@@ -3771,10 +3778,10 @@ impl Print for FuncAt<'_, Node> {
                         inputs.iter().enumerate().map(|(input_idx, input)| {
                             (
                                 input,
-                                Value::RegionInput {
+                                Value::Var(VarKind::RegionInput {
                                     region: body,
                                     input_idx: input_idx.try_into().unwrap(),
-                                },
+                                }),
                             )
                         });
                     (

--- a/src/qptr/lower.rs
+++ b/src/qptr/lower.rs
@@ -7,7 +7,7 @@ use crate::transform::{InnerInPlaceTransform, Transformed, Transformer};
 use crate::{
     AddrSpace, AttrSet, AttrSetDef, Const, ConstDef, ConstKind, Context, DataInst, DataInstDef,
     DataInstKind, Diag, FuncDecl, GlobalVarDecl, Node, NodeKind, NodeOutputDecl, OrdAssertEq,
-    Region, Type, TypeKind, TypeOrConst, Value, spv,
+    Region, Type, TypeKind, TypeOrConst, Value, VarKind, spv,
 };
 use itertools::Itertools as _;
 use smallvec::SmallVec;
@@ -284,7 +284,7 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
         let const_idx_as_i32 = |idx| match idx {
             // FIXME(eddyb) figure out the signedness semantics here.
             Value::Const(idx) => self.lowerer.const_as_u32(idx).map(|idx_u32| idx_u32 as i32),
-            _ => None,
+            Value::Var(_) => None,
         };
 
         let mut steps: SmallVec<[QPtrChainStep; 4]> = SmallVec::new();
@@ -576,7 +576,7 @@ impl LowerFromSpvPtrInstsInFunc<'_> {
                     func.nodes,
                 );
 
-                ptr = Value::NodeOutput { node: step_data_inst, output_idx: 0 };
+                ptr = Value::Var(VarKind::NodeOutput { node: step_data_inst, output_idx: 0 });
             }
             final_step.into_data_inst_kind_and_inputs(ptr)
         } else if spv_inst.opcode == wk.OpBitcast {

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -8,8 +8,8 @@ use crate::{
     AddrSpace, Attr, AttrSet, Const, ConstDef, ConstKind, Context, DataInst, DataInstDef,
     DataInstKind, DbgSrcLoc, DeclDef, ExportKey, Exportee, Func, FuncDecl, FuncParam, FxIndexMap,
     FxIndexSet, GlobalVar, GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect, Node,
-    NodeKind, NodeOutputDecl, OrdAssertEq, Region, RegionInputDecl, Type, TypeDef, TypeKind,
-    TypeOrConst, Value, VarKind,
+    NodeKind, OrdAssertEq, Region, Type, TypeDef, TypeKind, TypeOrConst, Value, Var, VarDecl,
+    VarKind,
 };
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
@@ -251,6 +251,10 @@ struct AllocatedIds<'a> {
 
 // FIXME(eddyb) should this use ID ranges instead of `SmallVec<[spv::Id; 4]>`?
 struct FuncLifting<'a> {
+    // HACK(eddyb) temporary workaround before it's clear how to map everything
+    // to use the new `Var` abstraction effectively.
+    vars: Option<&'a crate::EntityDefs<Var>>,
+
     func_id: spv::Id,
     param_ids: SmallVec<[spv::Id; 4]>,
 
@@ -530,6 +534,8 @@ impl<'a> FuncLifting<'a> {
         let func_def_body = match &func_decl.def {
             DeclDef::Imported(_) => {
                 return Ok(Self {
+                    vars: None,
+
                     func_id,
                     param_ids,
                     region_inputs_source: Default::default(),
@@ -560,7 +566,8 @@ impl<'a> FuncLifting<'a> {
                             .def()
                             .inputs
                             .iter()
-                            .map(|&RegionInputDecl { attrs, ty }| {
+                            .map(|&input_var| {
+                                let &VarDecl { attrs, ty, .. } = func_def_body.at(input_var).decl();
                                 Ok(Phi {
                                     attrs,
                                     ty,
@@ -593,15 +600,17 @@ impl<'a> FuncLifting<'a> {
 
                             loop_body_inputs
                                 .iter()
-                                .enumerate()
-                                .map(|(i, &RegionInputDecl { attrs, ty })| {
+                                .zip_eq(&node_def.inputs)
+                                .map(|(&input_var, &initial_value)| {
+                                    let &VarDecl { attrs, ty, .. } =
+                                        func_def_body.at(input_var).decl();
                                     Ok(Phi {
                                         attrs,
                                         ty,
 
                                         result_id: alloc_id()?,
                                         cases: FxIndexMap::default(),
-                                        default_value: Some(node_def.inputs[i]),
+                                        default_value: Some(initial_value),
                                     })
                                 })
                                 .collect::<Result<_, _>>()?
@@ -615,7 +624,9 @@ impl<'a> FuncLifting<'a> {
                         NodeKind::Select(_) => node_def
                             .outputs
                             .iter()
-                            .map(|&NodeOutputDecl { attrs, ty }| {
+                            .map(|&output_var| {
+                                let &VarDecl { attrs, ty, .. } =
+                                    func_def_body.at(output_var).decl();
                                 Ok(Phi {
                                     attrs,
                                     ty,
@@ -1053,6 +1064,8 @@ impl<'a> FuncLifting<'a> {
             .filter(|&inst| !func_def_body.at(inst).def().outputs.is_empty());
 
         Ok(Self {
+            vars: Some(&func_def_body.vars),
+
             func_id,
             param_ids,
             region_inputs_source,
@@ -1170,30 +1183,34 @@ impl LazyInst<'_, '_> {
 
                 _ => ids.globals[&Global::Const(ct)],
             },
-            Value::Var(VarKind::RegionInput { region, input_idx }) => {
-                let input_idx = usize::try_from(input_idx).unwrap();
-                match parent_func.region_inputs_source.get(&region) {
-                    Some(RegionInputsSource::FuncParams) => parent_func.param_ids[input_idx],
-                    Some(&RegionInputsSource::LoopHeaderPhis(loop_node)) => {
-                        parent_func.blocks[&CfgPoint::NodeEntry(loop_node)].phis[input_idx]
-                            .result_id
-                    }
-                    None => {
-                        parent_func.blocks[&CfgPoint::RegionEntry(region)].phis[input_idx].result_id
+            Value::Var(v) => match parent_func.vars.unwrap()[v].kind() {
+                VarKind::RegionInput { region, input_idx } => {
+                    let input_idx = usize::try_from(input_idx).unwrap();
+                    match parent_func.region_inputs_source.get(&region) {
+                        Some(RegionInputsSource::FuncParams) => parent_func.param_ids[input_idx],
+                        Some(&RegionInputsSource::LoopHeaderPhis(loop_node)) => {
+                            parent_func.blocks[&CfgPoint::NodeEntry(loop_node)].phis[input_idx]
+                                .result_id
+                        }
+                        None => {
+                            parent_func.blocks[&CfgPoint::RegionEntry(region)].phis[input_idx]
+                                .result_id
+                        }
                     }
                 }
-            }
-            Value::Var(VarKind::NodeOutput { node, output_idx }) => {
-                if let Some(&data_inst_output_id) = parent_func.data_inst_output_ids.get(&node) {
-                    // HACK(eddyb) multi-output instructions don't exist pre-disaggregate.
-                    assert_eq!(output_idx, 0);
-                    data_inst_output_id
-                } else {
-                    parent_func.blocks[&CfgPoint::NodeExit(node)].phis
-                        [usize::try_from(output_idx).unwrap()]
-                    .result_id
+                VarKind::NodeOutput { node, output_idx } => {
+                    if let Some(&data_inst_output_id) = parent_func.data_inst_output_ids.get(&node)
+                    {
+                        // HACK(eddyb) multi-output instructions don't exist pre-disaggregate.
+                        assert_eq!(output_idx, 0);
+                        data_inst_output_id
+                    } else {
+                        parent_func.blocks[&CfgPoint::NodeExit(node)].phis
+                            [usize::try_from(output_idx).unwrap()]
+                        .result_id
+                    }
                 }
-            }
+            },
         };
 
         let (result_id, attrs, _) = self.result_id_attrs_and_import(module, ids);
@@ -1358,7 +1375,7 @@ impl LazyInst<'_, '_> {
                     without_ids: inst,
                     // HACK(eddyb) multi-output instructions don't exist pre-disaggregate.
                     result_type_id: (data_inst_def.outputs.iter().at_most_one().ok().unwrap())
-                        .map(|o| ids.globals[&Global::Type(o.ty)]),
+                        .map(|&o| ids.globals[&Global::Type(parent_func.vars.unwrap()[o].ty)]),
                     result_id,
                     ids: extra_initial_id_operand
                         .into_iter()

--- a/src/spv/lift.rs
+++ b/src/spv/lift.rs
@@ -9,7 +9,7 @@ use crate::{
     DataInstKind, DbgSrcLoc, DeclDef, ExportKey, Exportee, Func, FuncDecl, FuncParam, FxIndexMap,
     FxIndexSet, GlobalVar, GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect, Node,
     NodeKind, NodeOutputDecl, OrdAssertEq, Region, RegionInputDecl, Type, TypeDef, TypeKind,
-    TypeOrConst, Value,
+    TypeOrConst, Value, VarKind,
 };
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
@@ -263,7 +263,7 @@ struct FuncLifting<'a> {
     blocks: FxIndexMap<CfgPoint, BlockLifting<'a>>,
 }
 
-/// What determines the values for [`Value::RegionInput`]s, for a specific
+/// What determines the values for [`VarKind::RegionInput`]s, for a specific
 /// region (effectively the subset of "region parents" that support inputs).
 ///
 /// Note that this is not used when a [`cf::unstructured::ControlInst`] has `target_inputs`,
@@ -793,8 +793,7 @@ impl<'a> FuncLifting<'a> {
                                     }
                                     _ => false,
                                 },
-
-                                _ => false,
+                                Value::Var(_) => false,
                             };
                             if is_infinite_loop {
                                 Terminator {
@@ -1171,7 +1170,7 @@ impl LazyInst<'_, '_> {
 
                 _ => ids.globals[&Global::Const(ct)],
             },
-            Value::RegionInput { region, input_idx } => {
+            Value::Var(VarKind::RegionInput { region, input_idx }) => {
                 let input_idx = usize::try_from(input_idx).unwrap();
                 match parent_func.region_inputs_source.get(&region) {
                     Some(RegionInputsSource::FuncParams) => parent_func.param_ids[input_idx],
@@ -1184,7 +1183,7 @@ impl LazyInst<'_, '_> {
                     }
                 }
             }
-            Value::NodeOutput { node, output_idx } => {
+            Value::Var(VarKind::NodeOutput { node, output_idx }) => {
                 if let Some(&data_inst_output_id) = parent_func.data_inst_output_ids.get(&node) {
                     // HACK(eddyb) multi-output instructions don't exist pre-disaggregate.
                     assert_eq!(output_idx, 0);

--- a/src/spv/lower.rs
+++ b/src/spv/lower.rs
@@ -8,7 +8,7 @@ use crate::{
     DbgSrcLoc, DeclDef, Diag, EntityDefs, ExportKey, Exportee, Func, FuncDecl, FuncDefBody,
     FuncParam, FxIndexMap, GlobalVarDecl, GlobalVarDefBody, Import, InternedStr, Module,
     NodeOutputDecl, Region, RegionDef, RegionInputDecl, Type, TypeDef, TypeKind, TypeOrConst,
-    Value, print,
+    Value, VarKind, print,
 };
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
@@ -1260,10 +1260,10 @@ impl Module {
 
                         local_id_defs.insert(
                             result_id.unwrap(),
-                            LocalIdDef::Value(Value::RegionInput {
+                            LocalIdDef::Value(Value::Var(VarKind::RegionInput {
                                 region: func_def_body.body,
                                 input_idx,
-                            }),
+                            })),
                         );
                     }
                     continue;
@@ -1328,10 +1328,10 @@ impl Module {
 
                                 (
                                     used_id,
-                                    LocalIdDef::Value(Value::RegionInput {
+                                    LocalIdDef::Value(Value::Var(VarKind::RegionInput {
                                         region: current_block.region,
                                         input_idx,
-                                    }),
+                                    })),
                                 )
                             },
                         ),
@@ -1503,10 +1503,10 @@ impl Module {
 
                     local_id_defs.insert(
                         result_id.unwrap(),
-                        LocalIdDef::Value(Value::RegionInput {
+                        LocalIdDef::Value(Value::Var(VarKind::RegionInput {
                             region: current_block.region,
                             input_idx,
-                        }),
+                        })),
                     );
                 } else if [wk.OpSelectionMerge, wk.OpLoopMerge].contains(&opcode) {
                     let is_second_to_last_in_block = lookahead_raw_inst(2)
@@ -1636,7 +1636,7 @@ impl Module {
 
                     let inst = func_def_body.nodes.define(&cx, data_inst_def.into());
                     if let Some(result_id) = result_id {
-                        let output = Value::NodeOutput { node: inst, output_idx: 0 };
+                        let output = Value::Var(VarKind::NodeOutput { node: inst, output_idx: 0 });
                         local_id_defs.insert(result_id, LocalIdDef::Value(output));
                     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -9,7 +9,7 @@ use crate::{
     DeclDef, EntityListIter, ExportKey, Exportee, Func, FuncDecl, FuncDefBody, FuncParam,
     GlobalVar, GlobalVarDecl, GlobalVarDefBody, Import, Module, ModuleDebugInfo, ModuleDialect,
     Node, NodeDef, NodeKind, NodeOutputDecl, OrdAssertEq, Region, RegionDef, RegionInputDecl, Type,
-    TypeDef, TypeKind, TypeOrConst, Value, spv,
+    TypeDef, TypeKind, TypeOrConst, Value, VarKind, spv,
 };
 use std::cmp::Ordering;
 use std::rc::Rc;
@@ -721,7 +721,16 @@ impl InnerTransform for Value {
             Self::Const(ct) => transform!({
                 ct -> transformer.transform_const_use(*ct),
             } => Self::Const(ct)),
+            Self::Var(var) => transform!({
+                var -> var.inner_transform_with(transformer),
+            } => Self::Var(var)),
+        }
+    }
+}
 
+impl InnerTransform for VarKind {
+    fn inner_transform_with(&self, _transformer: &mut impl Transformer) -> Transformed<Self> {
+        match self {
             Self::RegionInput { region: _, input_idx: _ }
             | Self::NodeOutput { node: _, output_idx: _ } => Transformed::Unchanged,
         }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -9,7 +9,7 @@ use crate::{
     DeclDef, DiagMsgPart, EntityListIter, ExportKey, Exportee, Func, FuncDecl, FuncDefBody,
     FuncParam, GlobalVar, GlobalVarDecl, GlobalVarDefBody, Import, Module, ModuleDebugInfo,
     ModuleDialect, Node, NodeDef, NodeKind, NodeOutputDecl, OrdAssertEq, Region, RegionDef,
-    RegionInputDecl, Type, TypeDef, TypeKind, TypeOrConst, Value, spv,
+    RegionInputDecl, Type, TypeDef, TypeKind, TypeOrConst, Value, VarKind, spv,
 };
 
 // FIXME(eddyb) `Sized` bound shouldn't be needed but removing it requires
@@ -547,8 +547,16 @@ impl InnerVisit for cf::unstructured::ControlInst {
 
 impl InnerVisit for Value {
     fn inner_visit_with<'a>(&'a self, visitor: &mut impl Visitor<'a>) {
+        match self {
+            &Self::Const(ct) => visitor.visit_const_use(ct),
+            Self::Var(var) => var.inner_visit_with(visitor),
+        }
+    }
+}
+
+impl InnerVisit for VarKind {
+    fn inner_visit_with<'a>(&'a self, _visitor: &mut impl Visitor<'a>) {
         match *self {
-            Self::Const(ct) => visitor.visit_const_use(ct),
             Self::RegionInput { region: _, input_idx: _ }
             | Self::NodeOutput { node: _, output_idx: _ } => {}
         }


### PR DESCRIPTION
*Note: this PR is a draft to avoid accidental merging onto its "base" branch (used as a form of ad-hoc PR stacking), and will remain as such, until its "base" branch can be set to `main`, i.e. all prerequisite PRs will have landed, up to and including this PR (whose branch is the "base" of this one):*
- https://github.com/Rust-GPU/spirt/pull/33

---

Before this PR, `Value` had these two variants (besides `Value::Const(Const)`):
- `Value::RegionInput { region: Region, input_idx: u32 }`
- `Value::NodeOutput { node: Node, output_idx: u32 }`

These "positional" references felt simple, but were fragile/inefficient in a few ways:
- any insertion/replacement/reordering of their declarations (other than adding new ones at the end) would require traversing all possible use locations, and correctly being able to remap indices
- significant complexity for any single pass updating definitions and uses as it goes (needing e.g. perfect knowledge of whether a use has been replaced already, or not, breaking on-demand access patterns, etc.)
- the exposed indices means that no possible API could be crafted to allow some mutation of the IR, but disallow accidental misuse of indices, detect misapplied substitutions, etc.

---

After this PR, those `Value` variants become a single `Value::Var(Var)`, where:
- `Var` is a new entity, mapping to a `VarDecl`
  (the name is more in the sense of lambda calculus and SSA, than anything like "memory-backed mutable variable")
- `RegionDef`'s `inputs` field and `NodeDef`'s `output` fields holds `Var`s now
- each `VarDecl` tracks the parent `Region`/`Node` *and the `Var`'s own index in that parent*

While `Var`s can themselves be misused, and require extra indirection and redundancy, now:
- only the `VarDecl`s have to be updated, not any `Var` uses, when making any additions/reorderings/removals/etc. to region inputs/node outputs, and `Var`s' "ownership" can even be moved from e.g. a region input to a node output (without having to update any of its uses)
- a pass willing to allocate new `Var`s can easily tell them apart from the old `Var`s it hasn't replaced yet, even if they might end up in the same positional slots of e.g. a node's outputs
- the redundancy allows `VarDecl`s to be checked against its parent region/node's list of `Var`s (and there is logic in the pretty-printer to do some of that, mostly to avoid a misleading view of the IR if some `Var`s have been orphaned/misplaced/etc.)

---

**TODO**: using the name "var(iable)" for this, while having some precedent in math/CS, does mean that `GlobalVar` and `mem::MemOp::FuncLocalVar` need to be updated to avoid overlapping with it - perhaps by describing those as "(memory) bindings" instead of "variables".